### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ How to use
 
         buildscript {
             repositories {
-                maven {
-                    jcenter()
-                }
+                jcenter()
             }
             dependencies {
                 classpath 'com.github.jengelman.gradle.plugins:shadow:0.8'


### PR DESCRIPTION
Defining jcenter() inside a maven{} block didn't work for me. The fix was to add it directly inside the repositories{} block instead as documented here: http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:maven_jcenter
