### PR TITLE
Zip entry actions

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/GradleVersionUtil.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/GradleVersionUtil.groovy
@@ -1,6 +1,8 @@
 package com.github.jengelman.gradle.plugins.shadow.internal
 
+import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.Action
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.ZipEntryCompression
@@ -19,12 +21,12 @@ class GradleVersionUtil {
         return mainSpec.buildRootResolver().getPatternSet()
     }
 
-    ZipCompressor getInternalCompressor(ZipEntryCompression entryCompression, Jar jar) {
+    ZipCompressor getInternalCompressor(ZipEntryCompression entryCompression, Jar jar, List<Action<ZipEntry>> actions) {
         switch (entryCompression) {
             case ZipEntryCompression.DEFLATED:
-                return new DefaultZipCompressor(jar.zip64, ZipOutputStream.DEFLATED);
+                return new DefaultZipCompressor(jar.zip64, ZipOutputStream.DEFLATED, actions);
             case ZipEntryCompression.STORED:
-                return new DefaultZipCompressor(jar.zip64, ZipOutputStream.STORED);
+                return new DefaultZipCompressor(jar.zip64, ZipOutputStream.STORED, actions);
             default:
                 throw new IllegalArgumentException(String.format("Unknown Compression type %s", entryCompression));
         }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.java
@@ -6,6 +6,7 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator;
 import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator;
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer;
 import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer;
+import org.apache.tools.zip.ZipEntry;
 import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 
@@ -18,6 +19,10 @@ interface ShadowSpec extends CopySpec {
     <T extends Transformer> ShadowSpec transform(Class<T> clazz, Action<T> configure) throws InstantiationException, IllegalAccessException;
 
     ShadowSpec transform(Transformer transformer);
+
+    ShadowSpec modifyZipEntries(Action<ZipEntry> zipEntryAction);
+
+    ShadowSpec zeroZipEntryTimestamps();
 
     ShadowSpec mergeServiceFiles();
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/util/PluginSpecification.groovy
@@ -2,6 +2,8 @@ package com.github.jengelman.gradle.plugins.shadow.util
 
 import com.github.jengelman.gradle.plugins.shadow.util.file.TestFile
 import com.google.common.base.StandardSystemProperty
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipFile
 import org.codehaus.plexus.util.IOUtil
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -106,6 +108,10 @@ class PluginSpecification extends Specification {
         is.close()
         jf.close()
         return sw.toString()
+    }
+
+    List<ZipEntry> getZipEntries(File f) {
+        new ZipFile(f).entries.toList()
     }
 
     void contains(File f, List<String> paths) {


### PR DESCRIPTION
A more general implementation of #246 , motivated by the same desire to have shadow jars that play nice with `rsync`. This implementation pushes a list of `Action<ZipEntry>` into the `ZipOutputStream` code so that all processed `ZipEntry`s can be run against them.

Arbitrary actions can be written in the build.gradle:

```
shadowJar{
    modifyZipEntries { ze ->
        println ze.hashCode()
        ze.setName("mutatedName")
        // ...
    }
}
```

And the motivating action has a sugared form:

```
shadowJar{
    zeroZipEntryTimestamps()
}
```

I'm a coworker of the requester for #246 , and lifted some of his comments and test code.