### PR TITLE
Allow package exclusion for ConfigureShadowRelocation

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ConfigureShadowRelocation.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ConfigureShadowRelocation.groovy
@@ -19,6 +19,9 @@ class ConfigureShadowRelocation extends DefaultTask {
     @Input
     String prefix = "shadow"
 
+    @Input
+    List<String> excludedPackages = []
+
     @InputFiles @Optional
     List<Configuration> getConfigurations() {
         return target.configurations
@@ -31,7 +34,7 @@ class ConfigureShadowRelocation extends DefaultTask {
             configuration.files.each { jar ->
                 JarFile jf = new JarFile(jar)
                 jf.entries().each { entry ->
-                    if (entry.name.endsWith(".class")) {
+                    if (entry.name.endsWith(".class") && !matchesExcludeList(entry.name)) {
                         packages << entry.name[0..entry.name.lastIndexOf('/')-1].replaceAll('/', '.')
                     }
                 }
@@ -48,4 +51,11 @@ class ConfigureShadowRelocation extends DefaultTask {
         return "configureRelocation${task.name.capitalize()}"
     }
 
+    boolean matchesExcludeList(String className) {
+        return excludedPackages.any {
+            if (className.startsWith(it)) {
+                return true
+            }
+        }
+    }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigureShadowRelocationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigureShadowRelocationSpec.groovy
@@ -24,7 +24,6 @@ class ConfigureShadowRelocationSpec extends PluginSpecification {
         runner.withArguments('shadowJar', '-s').build()
 
         then:
-        then:
         contains(output, [
                 'META-INF/MANIFEST.MF',
                 'shadow/junit/textui/ResultPrinter.class',
@@ -42,6 +41,46 @@ class ConfigureShadowRelocationSpec extends PluginSpecification {
                 'shadow/junit/framework/TestResult.class',
                 'shadow/junit/framework/TestSuite$1.class',
                 'shadow/junit/framework/TestSuite.class'
+        ])
+    }
+
+    def "auto relocate plugin dependencies with exclusion list"() {
+        given:
+        buildFile << """
+
+            task relocateShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) {
+                target = tasks.shadowJar
+                excludedPackages = ["junit/framework"]
+            }
+
+            tasks.shadowJar.dependsOn tasks.relocateShadowJar
+
+            dependencies {
+               compile 'junit:junit:3.8.2'
+            }
+        """.stripIndent()
+
+        when:
+        runner.withArguments('shadowJar', '-s').build()
+
+        then:
+        contains(output, [
+            'META-INF/MANIFEST.MF',
+            'shadow/junit/textui/ResultPrinter.class',
+            'shadow/junit/textui/TestRunner.class',
+            'junit/framework/Assert.class',
+            'junit/framework/AssertionFailedError.class',
+            'junit/framework/ComparisonCompactor.class',
+            'junit/framework/ComparisonFailure.class',
+            'junit/framework/Protectable.class',
+            'junit/framework/Test.class',
+            'junit/framework/TestCase.class',
+            'junit/framework/TestFailure.class',
+            'junit/framework/TestListener.class',
+            'junit/framework/TestResult$1.class',
+            'junit/framework/TestResult.class',
+            'junit/framework/TestSuite$1.class',
+            'junit/framework/TestSuite.class'
         ])
     }
 }


### PR DESCRIPTION
We've got a use case where we'd like to relocate all of our dependencies with 2 exceptions:

1. We have internal dependencies that contain a package that also exists in the project that is the target of shadowJar.  This causes all of the classes in that package to be relocated, which we don't want.
2. We have another library that is a thin wrapper around a 3rd party library.  We'd like to relocate all of the dependencies of this wrapper except for the specific 3rd party library.

Instead of using `relocate` and having to explicitly list all of the packages to include we'd rather use `ConfigureShadowRelocation` and explicitly exclude the 2 packages we don't want relocated.