### PR TITLE
Add a whitespace trimming mode to ManifestAppenderTransformer

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -72,7 +72,8 @@ class ManifestAppenderTransformer implements Transformer {
         ZipEntry entry = new ZipEntry(MANIFEST_NAME)
         entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
         os.putNextEntry(entry)
-        os.write(manifestContents)
+        os.write(trimTrailingWhitespace(manifestContents))
+        os.write(EOL)
 
         if (!attributes.isEmpty()) {
             for (attribute in attributes) {
@@ -84,5 +85,9 @@ class ManifestAppenderTransformer implements Transformer {
             os.write(EOL)
             attributes.clear()
         }
+    }
+
+    static byte[] trimTrailingWhitespace(byte[] contents) {
+        new String(contents, UTF_8).replaceFirst("\\n++$", "").getBytes(UTF_8)
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
@@ -41,11 +41,19 @@ class ManifestAppenderTransformer implements Transformer {
 
     private byte[] manifestContents = []
     private final List<Tuple2<String, ? extends Comparable<?>>> attributes = []
+    private boolean trimTrailingWhitespace = false
+
+    ManifestAppenderTransformer() {}
 
     List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
 
     ManifestAppenderTransformer append(String name, Comparable<?> value) {
         attributes.add(new Tuple2<String, ? extends Comparable<?>>(name, value))
+        this
+    }
+
+    ManifestAppenderTransformer trimTrailingWhitespace() {
+        trimTrailingWhitespace = true
         this
     }
 
@@ -72,8 +80,13 @@ class ManifestAppenderTransformer implements Transformer {
         ZipEntry entry = new ZipEntry(MANIFEST_NAME)
         entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
         os.putNextEntry(entry)
-        os.write(trimTrailingWhitespace(manifestContents))
-        os.write(EOL)
+
+        if (trimTrailingWhitespace) {
+            os.write(trimTrailingWhitespace(manifestContents))
+            os.write(EOL)
+        } else {
+            os.write(manifestContents)
+        }
 
         if (!attributes.isEmpty()) {
             for (attribute in attributes) {
@@ -88,6 +101,6 @@ class ManifestAppenderTransformer implements Transformer {
     }
 
     static byte[] trimTrailingWhitespace(byte[] contents) {
-        new String(contents, UTF_8).replaceFirst("\\n++$", "").getBytes(UTF_8)
+        new String(contents, UTF_8).replaceFirst("\\s++\$", "").getBytes(UTF_8)
     }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.groovy
@@ -89,7 +89,6 @@ class ManifestAppenderTransformerTest extends TransformerTestSupport {
         }
 
         def targetLines = readFrom(testableZipFile, MANIFEST_NAME)
-        println(targetLines)
         assertFalse(targetLines.isEmpty())
         assertTrue(targetLines.size() > 4)
 


### PR DESCRIPTION
Hi there,

We use the ManifestAppenderTransformer in a Gradle plugin that wraps the Shadow plugin: https://github.com/palantir/gradle-shadow-jar. 

We've tried to use the ManifestAppenderTransformer to add tags to an existing manifest file. However, existing manifest files often have a blank line at the end, and so the current transformer if used to extend such a file will leave a blank line between the existing content and any added tags. In other words, if we tried to add the tag `bar: 1234` to a manifest with a tag `foo: 123` _and a blank line at the end_, we get

```
foo: 123

bar: 1234
```

This PR extends the transformer with a mode where it trims whitespace, so that tags are added to the last section of the manifest (as opposed to beginning a new section). This would allow using this transformer to add tags to the main section of an existing manifest (which is what we are trying to do with the plugin when shading a multi-release jar). With this mode you would obtain

```
foo: 123
bar: 1234
```

This is strictly opt-in, so existing users should not be affected.

@iamdanfox for SA