### PR TITLE
Allow for opt-out of the java shadowRuntimeElements variant

### DIFF
--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.groovy
@@ -12,10 +12,12 @@ class ShadowExtension {
 
     CopySpec applicationDistribution
     Project project
+    boolean addJavaVariants
 
     ShadowExtension(Project project) {
         this.project = project
         applicationDistribution = project.copySpec {}
+        addJavaVariants = true
     }
 
     void component(MavenPublication publication) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy
@@ -50,9 +50,13 @@ class ShadowJavaPlugin implements Plugin<Project> {
 
         project.configurations.shadowRuntimeElements.extendsFrom project.configurations.shadow
 
-        project.components.java {
-            addVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
-                mapToOptional() // make it a Maven optional dependency
+        project.afterEvaluate {
+            if (project.extensions.findByName(ShadowBasePlugin.EXTENSION_NAME).addJavaVariants) {
+                project.components.java {
+                    addVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
+                        mapToOptional() // make it a Maven optional dependency
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Add a extension property to regulate whether a new variant is added to the java component. I must admit I don't know exactly why the variant was added. The [commit message](https://github.com/johnrengelman/shadow/commit/5c572a68bebf712a99854685d6c2834d146f9924) was only about support for Gradle 5 -> 6. So this is just a proposal.
Closes #651