### PR TITLE
Add the ability to rename annotations added by the Scala compiler.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation('org.vafer:jdependency:2.7.0') {
         exclude group: 'org.ow2.asm'
     }
+    // For Scala annotation remapping
+    implementation 'com.eed3si9n.jarjarabrams:jarjar-abrams-core_2.13:1.8.1'
 
     testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
         exclude group: 'org.codehaus.groovy'

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/impl/RelocatorRemapper.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/impl/RelocatorRemapper.groovy
@@ -50,9 +50,13 @@ class RelocatorRemapper extends Remapper {
         this.stats = stats
         this.scalaRenamer =
             new FunctionWrappers.FromJavaFunction(
-                (String string) -> {
-                    Optional<Relocator> maybe = relocators.stream().filter(x -> x.canRelocateClass(string)).findAny()
-                    Option.apply(maybe.map(it.relocateClass(new RelocateClassContext(string, stats))).orElse(null))
+                (String name) -> {
+                    Optional<Relocator> maybeRelocator = relocators.stream().filter(x -> x.canRelocateClass(name)).findAny()
+                    String rewritten =
+                        maybeRelocator
+                            .map(relocator -> relocator.relocateClass(new RelocateClassContext(name, stats)))
+                            .orElse(null)
+                    Option.apply(rewritten)
                 }
             )
     }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
+import com.eed3si9n.jarjarabrams.scalasig.ScalaSigClassVisitor
 import com.github.jengelman.gradle.plugins.shadow.ShadowStats
 import com.github.jengelman.gradle.plugins.shadow.impl.RelocatorRemapper
 import com.github.jengelman.gradle.plugins.shadow.internal.GradleVersionUtil
@@ -348,7 +349,7 @@ class ShadowCopyAction implements CopyAction {
             // that use the constant pool to determine the dependencies of a class.
             ClassWriter cw = new ClassWriter(0)
 
-            ClassVisitor cv = new ClassRemapper(cw, remapper)
+            ClassVisitor cv = new ScalaSigClassVisitor(new ClassRemapper(cw, remapper), remapper.scalaRenamer)
 
             try {
                 cr.accept(cv, ClassReader.EXPAND_FRAMES)


### PR DESCRIPTION
This is for https://github.com/johnrengelman/shadow/issues/146. I haven't tested the new functionality, but existing tests pass.