### PR TITLE
Fix deprecation when running on Gradle 8.8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -128,13 +128,9 @@ class ShadowApplicationPlugin implements Plugin<Project> {
             }
             into("bin") {
                 from(startScripts)
-                if (GradleVersion.current() >= GradleVersion.version("8.3")) {
                     filePermissions {
                         it.unix(493)
                     }
-                } else {
-                    fileMode = 493
-                }
             }
         }
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.distribution.Distribution
 import org.gradle.api.distribution.DistributionContainer
+import org.gradle.api.file.CopyProcessingSpec
 import org.gradle.api.file.CopySpec
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.JavaApplication
@@ -17,6 +18,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.util.GradleVersion
 
 class ShadowApplicationPlugin implements Plugin<Project> {
 
@@ -126,7 +128,13 @@ class ShadowApplicationPlugin implements Plugin<Project> {
             }
             into("bin") {
                 from(startScripts)
-                fileMode = 493
+                if (GradleVersion.current() >= GradleVersion.version("8.3")) {
+                    filePermissions {
+                        it.unix(493)
+                    }
+                } else {
+                    fileMode = 493
+                }
             }
         }
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.groovy
@@ -13,8 +13,8 @@ class ShadowBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        if (GradleVersion.current() < GradleVersion.version("8.0")) {
-            throw new GradleException("This version of Shadow supports Gradle 8.0+ only. Please upgrade.")
+        if (GradleVersion.current() < GradleVersion.version("8.3")) {
+            throw new GradleException("This version of Shadow supports Gradle 8.3+ only. Please upgrade.")
         }
         project.extensions.create(EXTENSION_NAME, ShadowExtension, project)
         createShadowConfiguration(project)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.UncheckedIOException
 import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.file.FilePermissions
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.DocumentationRegistry
@@ -508,6 +509,11 @@ class ShadowCopyAction implements CopyAction {
         @Override
         boolean copyTo(File file) {
             return false
+        }
+
+        @Override
+        FilePermissions getPermissions() {
+            return null
         }
 
         @Override

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ApplicationSpec.groovy
@@ -29,7 +29,7 @@ class ApplicationSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'application'
 
-            mainClassName = 'myapp.Main'
+            application.mainClass = 'myapp.Main'
             
             dependencies {
                implementation 'shadow:a:1.0'
@@ -90,7 +90,7 @@ class ApplicationSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'application'
 
-            mainClassName = 'myapp.Main'
+            application.mainClass = 'myapp.Main'
             
             dependencies {
                implementation 'shadow:a:1.0'
@@ -169,7 +169,7 @@ class ApplicationSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'application'
 
-            mainClassName = 'myapp.Main'
+            application.mainClass = 'myapp.Main'
             
             dependencies {
                shadow 'shadow:a:1.0'
@@ -219,7 +219,7 @@ class ApplicationSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'application'
 
-            mainClassName = 'myapp.Main'
+            application.mainClass = 'myapp.Main'
             
             dependencies {
                implementation 'shadow:a:1.0'

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ConfigurationCacheSpec.groovy
@@ -35,7 +35,7 @@ class ConfigurationCacheSpec extends PluginSpecification {
         buildFile << """
             apply plugin: 'application'
 
-            mainClassName = 'myapp.Main'
+            application.mainClass = 'myapp.Main'
             
             dependencies {
                implementation 'shadow:a:1.0'

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPluginSpec.groovy
@@ -86,7 +86,7 @@ class ShadowPluginSpec extends PluginSpecification {
         assert output.exists()
 
         where:
-        version << ['8.0']
+        version << ['8.3']
     }
 
     def 'Error in Gradle versions < 8.0'() {


### PR DESCRIPTION
`CopyProcessingSpec.fileMode` was recently deprecated. It is replaced by
the `filePermissions` method, that was introduced in 8.3.
For that reason this change updates the build to 8.3 to be able to call
`filePermissions`. The code then uses that method if running on 8.3 or
higher. If not, it falls back to calling `fileMode`.
