### PR TITLE
Add missing dependency to `yarn_build`

### DIFF
--- a/gradle/vuepress.gradle
+++ b/gradle/vuepress.gradle
@@ -7,4 +7,5 @@ node {
 tasks.named('yarn_build') {
     inputs.files project.fileTree('src/docs')
     outputs.dir project.file('build/site')
+    dependsOn("yarn")
 }


### PR DESCRIPTION
The rule-generated `yarn_` tasks only get the dependency on the YarnInstallTask if they start with `yarn_run_`

So to make sure `yarn_build` works I've added the dependency manually