### PR TITLE
Mention original owner and plugin ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Gradle plugin for creating fat/uber JARs with support for package relocation.
 
 > [!NOTE]\
-> Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID `com.github.johnrengelman.shadow`
+> Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID [`com.github.johnrengelman.shadow`](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow)
 > before maintenance was transferred to the [GradleUp organization](https://github.com/GradleUp) to ensure future development, see [#908](https://github.com/GradleUp/shadow/issues/908).
 >
-> If you are still using the old plugin ID in your build script, we recommend to switch to the [new plugin ID `com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
+> If you are still using the old plugin ID in your build script, we recommend to switch to the new plugin ID [`com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
 > and update to the latest version to receive all the latest bug fixes and improvements.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Gradle plugin for creating fat/uber JARs with support for package relocation.
 
+> [!NOTE]\
+> Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID `com.github.johnrengelman.shadow`
+> before maintenance was transferred to the [GradleUp organization](https://github.com/GradleUp) to ensure future development, see [#908](https://github.com/GradleUp/shadow/issues/908).
+>
+> If you are still using the old plugin ID in your build script, we recommend to switch to the [new plugin ID `com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
+> and update to the latest version to receive all the latest bug fixes and improvements.
+
 ## Documentation
 
 Read the [User Guide](https://gradleup.com/shadow/)!

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -7,6 +7,10 @@ actionText: User Guide →
 actionLink: /introduction/
 ---
 
-John Engelman - @johnrengelman
-
 [API Docs](https://gradleup.com/shadow/api/index.html)
+
+Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID `com.github.johnrengelman.shadow`
+before maintenance was transferred to the [GradleUp organization](https://github.com/GradleUp) to ensure future development, see [#908](https://github.com/GradleUp/shadow/issues/908).
+
+If you are still using the old plugin ID in your build script, we recommend to switch to the [new plugin ID `com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
+and update to the latest version to receive all the latest bug fixes and improvements.

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -9,8 +9,8 @@ actionLink: /introduction/
 
 [API Docs](https://gradleup.com/shadow/api/index.html)
 
-Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID `com.github.johnrengelman.shadow`
+Previously this plugin was developed by [@johnrengelman](https://github.com/johnrengelman) and published under the ID [`com.github.johnrengelman.shadow`](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow)
 before maintenance was transferred to the [GradleUp organization](https://github.com/GradleUp) to ensure future development, see [#908](https://github.com/GradleUp/shadow/issues/908).
 
-If you are still using the old plugin ID in your build script, we recommend to switch to the [new plugin ID `com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
+If you are still using the old plugin ID in your build script, we recommend to switch to the new plugin ID [`com.gradleup.shadow`](https://plugins.gradle.org/plugin/com.gradleup.shadow)
 and update to the latest version to receive all the latest bug fixes and improvements.


### PR DESCRIPTION
See https://github.com/GradleUp/shadow/pull/928#issuecomment-2257050924
Existing users of the plugin might still remember the old owner and plugin ID, so this should hopefully reduce confusion and give further insight into the change.

Any feedback, especially regarding formatting or wording, is appreciated!