### PR TITLE
Stop excluding ASM from jdependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,16 +14,13 @@ dependencies {
     compileOnly(localGroovy())
 
     implementation("org.jdom:jdom2:2.0.6.1")
-    implementation("org.ow2.asm:asm:9.7")
     implementation("org.ow2.asm:asm-commons:9.7")
     implementation("commons-io:commons-io:2.16.1")
     implementation("org.apache.ant:ant:1.10.15")
     implementation("org.codehaus.plexus:plexus-utils:4.0.1")
     implementation("org.codehaus.plexus:plexus-xml:4.0.4")
     implementation("org.apache.logging.log4j:log4j-core:2.24.0")
-    implementation("org.vafer:jdependency:2.10") {
-        exclude(group = "org.ow2.asm")
-    }
+    implementation("org.vafer:jdependency:2.10")
 
     testImplementation("org.spockframework:spock-core:2.3-groovy-3.0") {
         exclude(group = "org.codehaus.groovy")


### PR DESCRIPTION
Now it's shadowed.

```
runtimeClasspath - Runtime classpath of source set 'main'.
+--- org.jdom:jdom2:2.0.6.1
+--- org.ow2.asm:asm:9.7
+--- org.ow2.asm:asm-commons:9.7
|    +--- org.ow2.asm:asm:9.7
|    \--- org.ow2.asm:asm-tree:9.7
|         \--- org.ow2.asm:asm:9.7
+--- commons-io:commons-io:2.16.1
+--- org.apache.ant:ant:1.10.15
|    \--- org.apache.ant:ant-launcher:1.10.15
+--- org.codehaus.plexus:plexus-utils:4.0.1
+--- org.codehaus.plexus:plexus-xml:4.0.4
|    \--- org.apache.maven:maven-xml-impl:4.0.0-alpha-9
|         +--- org.apache.maven:maven-api-xml:4.0.0-alpha-9
|         |    \--- org.apache.maven:maven-api-meta:4.0.0-alpha-9
|         \--- com.fasterxml.woodstox:woodstox-core:6.5.1
|              \--- org.codehaus.woodstox:stax2-api:4.2.1
+--- org.apache.logging.log4j:log4j-core:2.24.0
|    \--- org.apache.logging.log4j:log4j-api:2.24.0
\--- org.vafer:jdependency:2.10
```