### PR TITLE
fix: StringIndexOutOfBoundsException when from is emtpy

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+**Fixed**
+
+- Avoid `StringIndexOutOfBoundsException` when relocating from empty string.
 
 ## [v8.3.2]
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.groovy
@@ -151,6 +151,10 @@ class SimpleRelocator implements Relocator {
 
     @Override
     boolean canRelocatePath(String path) {
+        if (path.isEmpty()) {
+            return false
+        }
+
         if (rawString) {
             return Pattern.compile(pathPattern).matcher(path).find()
         }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.groovy
@@ -46,6 +46,7 @@ class SimpleRelocatorTest extends TestCase {
         SimpleRelocator relocator
 
         relocator = new SimpleRelocator("org.foo", null, null, null)
+        assertEquals(false, relocator.canRelocatePath(""))
         assertEquals(true, relocator.canRelocatePath("org/foo/Class"))
         assertEquals(true, relocator.canRelocatePath("org/foo/Class.class"))
         assertEquals(true, relocator.canRelocatePath("org/foo/bar/Class"))


### PR DESCRIPTION
When:

```groovy
  shadowJar {
    relocate "", "whatever"
  }
```

It crashes with:

```
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 0
        at java.base/java.lang.StringLatin1.charAt(StringLatin1.java:48)
        at java.base/java.lang.String.charAt(String.java:1517)
        at java_lang_CharSequence$charAt$1.call(Unknown Source)
        at com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator.canRelocatePath(SimpleRelocator.groovy:172)
        at com.github.jengelman.gradle.plugins.shadow.relocation.Relocator$canRelocatePath.callCurrent(Unknown Source)
        at com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator.canRelocateClass(SimpleRelocator.groovy:182)
        at com.github.jengelman.gradle.plugins.shadow.relocation.Relocator$canRelocateClass$1.call(Unknown Source)
        at com.github.jengelman.gradle.plugins.shadow.impl.RelocatorRemapper.mapValue(RelocatorRemapper.groovy:69)
```

---

- [x] [CHANGELOG](src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
