### PR TITLE
Apply legacy plugin last, and declare capabilities for old plugins

### DIFF
--- a/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
@@ -47,7 +47,7 @@ tasks.withType<Javadoc>().configureEach {
 }
 
 configurations {
-  sequenceOf(
+  listOf(
     apiElements,
     runtimeElements,
     named("javadocElements"),

--- a/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
@@ -45,3 +45,39 @@ tasks.withType<Javadoc>().configureEach {
     it.addStringOption("Xdoclint:none", "-quiet")
   }
 }
+
+configurations {
+  sequenceOf(
+    apiElements,
+    runtimeElements,
+    named("javadocElements"),
+    named("sourcesElements"),
+  ).forEach {
+    it.configure {
+      attributes {
+        // We have dependencies that require Java 11 (jdependency)
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
+      }
+
+      outgoing {
+        // Main/current capability
+        capability("com.gradleup.shadow:shadow-gradle-plugin:$version")
+
+        // Historical capabilities
+        capability("io.github.goooler.shadow:shadow-gradle-plugin:$version")
+        capability("com.github.johnrengelman:shadow:$version")
+        capability("gradle.plugin.com.github.jengelman.gradle.plugins:shadow:$version")
+        capability("gradle.plugin.com.github.johnrengelman:shadow:$version")
+        capability("com.github.jengelman.gradle.plugins:shadow:$version")
+      }
+    }
+  }
+}
+
+publishing.publications.withType<MavenPublication>().configureEach {
+  // We don't care about capabilities being unmappable to Maven
+  suppressPomMetadataWarningsFor("apiElements")
+  suppressPomMetadataWarningsFor("runtimeElements")
+  suppressPomMetadataWarningsFor("javadocElements")
+  suppressPomMetadataWarningsFor("sourcesElements")
+}

--- a/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
@@ -54,11 +54,6 @@ configurations {
     named("sourcesElements"),
   ).forEach {
     it.configure {
-      attributes {
-        // We have dependencies that require Java 11 (jdependency)
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
-      }
-
       outgoing {
         // Main/current capability
         capability("com.gradleup.shadow:shadow-gradle-plugin:$version")

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,7 +3,9 @@
 
 ## [Unreleased]
 
-- Apply legacy plugin last, and declare capabilities for old plugins, fixes [#964](https://github.com/GradleUp/shadow/issues/964) ([#991](https://github.com/GradleUp/shadow/pull/991))
+**Fixed**
+
+- Apply legacy plugin last, and declare capabilities for old plugins, fixes [#964](https://github.com/GradleUp/shadow/issues/964). ([#991](https://github.com/GradleUp/shadow/pull/991))
 
 ## [v8.3.2]
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,7 +3,7 @@
 
 ## [Unreleased]
 
-- Apply legacy plugin last, and declare capabilities for old plugins, fixes [#964](https://github.com/GradleUp/shadow/pull/964) ([#991](https://github.com/GradleUp/shadow/pull/991))
+- Apply legacy plugin last, and declare capabilities for old plugins, fixes [#964](https://github.com/GradleUp/shadow/issues/964) ([#991](https://github.com/GradleUp/shadow/pull/991))
 
 ## [v8.3.2]
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,7 @@
 
 ## [Unreleased]
 
+- Apply legacy plugin last, and declare capabilities for old plugins, fixes [#964](https://github.com/GradleUp/shadow/pull/964) ([#991](https://github.com/GradleUp/shadow/pull/991))
 
 ## [v8.3.2]
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
@@ -13,13 +13,18 @@ class ShadowPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.with {
             plugins.apply(ShadowBasePlugin)
-            plugins.apply(LegacyShadowPlugin)
             plugins.withType(JavaPlugin) {
                 plugins.apply(ShadowJavaPlugin)
             }
             plugins.withType(ApplicationPlugin) {
                 plugins.apply(ShadowApplicationPlugin)
             }
+            // Apply the legacy plugin last
+            //   Because we apply the ShadowJavaPlugin/ShadowApplication plugin in a withType callback for the
+            //   respective JavaPlugin/ApplicationPlugin, it may still apply before the shadowJar task is created and
+            //   etc. if the user applies shadow before those plugins. However, this is fine, because this was also
+            //   the behavior with the old plugin when applying in that order.
+            plugins.apply(LegacyShadowPlugin)
 
             // Legacy build scan support for Gradle Enterprise, users should migrate to develocity plugin.
             rootProject.plugins.withId('com.gradle.enterprise') {


### PR DESCRIPTION
fixes #964 using the solution suggested by @ljacomet at https://github.com/GradleUp/shadow/issues/964#issuecomment-2345532565

Tested to fix the issue (bring behavior back to how it was before 8.3.1/with the old plugin), and to give an error when both the current and old plugin are on the classpath.

Something else that came to mind regarding the legacy plugin is that if someone puts the new plugin on the classpath, but then applies the legacy plugin id, nothing will happen, which could be confusing. But resolving that is likely better addressed in a separate PR (if at all).

```
> Could not resolve all files for configuration ':build-logic:compileClasspath'.
   > Could not resolve com.gradleup.shadow:shadow-gradle-plugin:8.3.3-SNAPSHOT.
     Required by:
         project :build-logic
      > Module 'com.gradleup.shadow:shadow-gradle-plugin' has been rejected:
           Cannot select module with conflict on capability 'com.github.johnrengelman:shadow:8.3.3-SNAPSHOT' also provided by [com.github.johnrengelman:shadow:8.1.1(apiElements)]
   > Could not resolve com.github.johnrengelman:shadow:8.1.1.
     Required by:
         project :build-logic
      > Module 'com.github.johnrengelman:shadow' has been rejected:
           Cannot select module with conflict on capability 'com.github.johnrengelman:shadow:8.1.1' also provided by [com.gradleup.shadow:shadow-gradle-plugin:8.3.3-SNAPSHOT(apiElements)]
```

---

- [x] [CHANGELOG](src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
