### PR TITLE
Disable Develocity integration by default

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Changed**
+
+- Disable Develocity integration by default. ([#993](https://github.com/GradleUp/shadow/pull/993))
+
 
 ## [v8.3.2]
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
@@ -23,7 +23,7 @@ class ShadowPlugin implements Plugin<Project> {
 
             boolean enableDevelocityIntegration = providers.gradleProperty(
                 "com.gradleup.shadow.enableDevelocityIntegration"
-            ).map { it.toBoolean() }.getOrElse(true)
+            ).map { it.toBoolean() }.getOrElse(false)
             if (enableDevelocityIntegration) {
                 // Legacy build scan support for Gradle Enterprise, users should migrate to develocity plugin.
                 rootProject.plugins.withId('com.gradle.enterprise') {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowPlugin.groovy
@@ -21,12 +21,17 @@ class ShadowPlugin implements Plugin<Project> {
                 plugins.apply(ShadowApplicationPlugin)
             }
 
-            // Legacy build scan support for Gradle Enterprise, users should migrate to develocity plugin.
-            rootProject.plugins.withId('com.gradle.enterprise') {
-                configureBuildScan(rootProject)
-            }
-            rootProject.plugins.withId('com.gradle.develocity') {
-                configureBuildScan(rootProject)
+            boolean enableDevelocityIntegration = providers.gradleProperty(
+                "com.gradleup.shadow.enableDevelocityIntegration"
+            ).map { it.toBoolean() }.getOrElse(true)
+            if (enableDevelocityIntegration) {
+                // Legacy build scan support for Gradle Enterprise, users should migrate to develocity plugin.
+                rootProject.plugins.withId('com.gradle.enterprise') {
+                    configureBuildScan(rootProject)
+                }
+                rootProject.plugins.withId('com.gradle.develocity') {
+                    configureBuildScan(rootProject)
+                }
             }
         }
     }


### PR DESCRIPTION
Configuring develocity build scan additional detail publishing breaks Gradle project isolation https://github.com/GradleUp/shadow/issues/907

This change adds a new property com.gradleup.shadow.enableDevelocityIntegration that defaults to true, however it allows folks to set it to false and make shadow plugin usage project isolation safe.

---

- [x] [CHANGELOG](src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
