### PR TITLE
Fix documentation of custom tasks

### DIFF
--- a/src/docs/custom-tasks/README.md
+++ b/src/docs/custom-tasks/README.md
@@ -12,11 +12,11 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 task testJar(type: ShadowJar) {
   archiveClassifier.set("tests")
   from sourceSets.test.output
-  configurations = [project.configurations.testImplementation]
+  configurations = [project.configurations.testRuntimeClasspath]
 }
 ```
 
-The code snippet above will generate a shadowed JAR containing both the `main` and `test` sources as well as all `runtime`
+The code snippet above will generate a shadowed JAR containing both the `main` and `test` sources as well as all `testRuntimeOnly`
 and `testImplementation` dependencies.
 The file is output to `build/libs/<project>-<version>-tests.jar`.
     


### PR DESCRIPTION
---

Adapts the docs at https://gradleup.com/shadow/custom-tasks/.

Using `testImplementation` does not work anymore with latest Gradle versions. It produces the following error:
```
Could not determine the dependencies of task ':testJar'.
> Resolving dependency configuration 'testImplementation' is not allowed as it is defined as 'canBeResolved=false'.
  Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'testImplementation' should be resolved.
```

Instead, [Gradle docs](https://docs.gradle.org/current/userguide/java_plugin.html) hints that `testRuntimeClasspath` is a resolvable configuration. 