### PR TITLE
Links from doc to source should point to main branch

### DIFF
--- a/src/docs/.vuepress/config.js
+++ b/src/docs/.vuepress/config.js
@@ -4,6 +4,7 @@ module.exports = {
   ga: "UA-321220-4",
   themeConfig: {
     repo: "GradleUp/shadow",
+    docsBranch: 'main',
     editLinks: true,
     editLinkText: 'Help improve these docs!',
     logo: '/logo+type.svg',


### PR DESCRIPTION
Every doc page has a link labeld "Help improve these docs!" which produce 404s, e.g.: https://github.com/GradleUp/shadow/edit/master/src/docs/custom-tasks/README.md. 

According to [Vuepress docs](https://v1.vuepress.vuejs.org/theme/default-theme-config.html#git-repository-and-edit-links) one can change the branch via `docsBranch` property. I did not try if the change actually fixes the problem.