### PR TITLE
Revert "Bump Java level to 11"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 spotless {

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+**Fixed**
+
+- Revert "Bump Java level to 11" ([#1011](https://github.com/GradleUp/shadow/issues/1011)).
+  Shadow will bump Java level to 11 or above in the next major release, reverts it here for keeping compatibility with 8.x versions.
+
 
 ## [v8.3.4] (2024-10-29)
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 **Fixed**
 
-- Revert "Bump Java level to 11" ([#1011](https://github.com/GradleUp/shadow/issues/1011)).
+- Revert "Bump Java level to 11" ([#1011](https://github.com/GradleUp/shadow/issues/1011)).  
   Shadow will bump Java level to 11 or above in the next major release, reverts it here for keeping compatibility with 8.x versions.
 
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -6,7 +6,7 @@
 **Fixed**
 
 - Revert "Bump Java level to 11" ([#1011](https://github.com/GradleUp/shadow/issues/1011)).  
-  Shadow will bump Java level to 11 or above in the next major release, reverts it here for keeping compatibility with 8.x versions.
+  This reverts the change to maintain compatibility with 8.x versions. The Java level will be bumped to 11 or above in the next major release.
 
 
 ## [v8.3.4] (2024-10-29)


### PR DESCRIPTION
This reverts commit #994.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
