### PR TITLE
Fix publishing docs after API change

### DIFF
--- a/src/docs/publishing/README.md
+++ b/src/docs/publishing/README.md
@@ -4,8 +4,8 @@
 
 The Shadow plugin will automatically configure the necessary tasks in the presence of Gradle's
 `maven-publish` plugin.
-The plugin provides the `component` method from the `shadow` extension to configure the
-publication with the necessary artifact and dependencies in the POM file.
+The plugin provides the `shadow` component to configure the publication with the necessary
+artifact and dependencies in the POM file.
 
 ```groovy
 // Publishing a Shadow JAR with the Maven-Publish Plugin
@@ -16,7 +16,7 @@ apply plugin: 'com.gradleup.shadow'
 publishing {
   publications {
     shadow(MavenPublication) {
-      components.shadow
+      from(components.shadow) // or components["shadow"] in Kotlin DSL
     }
   }
   repositories {


### PR DESCRIPTION
- Calling `from()` is necessary
- Update text to describe new API
- Add Kotlin DSL equivalent as comment

---

- [x] ~~[CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.~~