### PR TITLE
Introducing Gradle Shadow Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Read the [User Guide](https://gradleup.com/shadow/)!
 [![Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.gradleup.shadow)](https://plugins.gradle.org/plugin/com.gradleup.shadow)
 [![CI](https://github.com/GradleUp/shadow/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/GradleUp/shadow/actions/workflows/ci.yml?query=branch:main+event:push)
 [![License](https://img.shields.io/github/license/GradleUp/shadow.svg)](LICENSE)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Gradle%20Shadow%20Guru-006BFF)](https://gurubase.io/g/gradle-shadow)
 
 ## Latest Test Compatibility
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Gradle Shadow Guru](https://gurubase.io/g/gradle-shadow) to Gurubase. Gradle Shadow Guru uses the data from this repo and data from the [docs](https://gradleup.com/shadow/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Gradle Shadow Guru", which highlights that Gradle Shadow now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Gradle Shadow Guru in Gurubase, just let me know that's totally fine.
