### PR TITLE
Fix single Log4j2Plugins.dat isn't included into fat jar

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -11,6 +11,10 @@
 
 - **BREAKING CHANGE:** Remove Develocity integration. ([#1013](https://github.com/GradleUp/shadow/pull/1013))
 
+**Fixed**
+
+- Fix single Log4j2Plugins.dat isn't included into fat jar. ([#1039](https://github.com/GradleUp/shadow/issues/1039)).  
+
 
 ## [v8.3.5] (2024-11-03)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
@@ -53,9 +53,7 @@ public open class Log4j2PluginsCacheFileTransformer : Transformer {
     // This functionality matches the original plugin, however, I'm not clear what
     // the exact logic is. From what I can tell temporaryFiles should be never be empty
     // if anything has been performed.
-    val hasTransformedMultipleFiles = temporaryFiles.size > 1
-    val hasAtLeastOneFileAndRelocator = temporaryFiles.isNotEmpty() && relocators.isNotEmpty()
-    return hasTransformedMultipleFiles || hasAtLeastOneFileAndRelocator
+    return temporaryFiles.isNotEmpty() || relocators.isNotEmpty()
   }
 
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerSpec.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerSpec.groovy
@@ -25,12 +25,12 @@ class Log4j2PluginsCacheFileTransformerSpec extends Specification {
         transformer = new Log4j2PluginsCacheFileTransformer()
     }
 
-    void "should not transformer"() {
+    void "should transform for a single file"() {
         when:
         transformer.transform(new TransformerContext(PLUGIN_CACHE_FILE, getResourceStream(PLUGIN_CACHE_FILE)))
 
         then:
-        !transformer.hasTransformedResource()
+        transformer.hasTransformedResource()
     }
 
     void "should transform"() {


### PR DESCRIPTION
Probably when an application is single module jar, there's no `Log4j2Plugins.dat` file in `META-INF`, that causes a warning `No Log4j plugin descriptor was found in the classpath.`.

I saw that `Log4j2PluginCacheFileTransformer.java` class was inspired by [this repo](https://github.com/apache/logging-log4j-transform) and there was a [fix](https://github.com/apache/logging-log4j-transform/commit/d4393b6be63c83697727b7f5b9c02e15381ae704) for a fat jar apps. Already tested locally and now it works.

Refs https://github.com/apache/logging-log4j-transform/pull/42.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.