### PR TITLE
Add .md support to the Apache License and Notice transformers

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Added**
+
+- Add .md support to the Apache License and Notice transformers. ([#1041](https://github.com/GradleUp/shadow/pull/1041))
+
 **Changed**
 
 - **BREAKING CHANGE:** Rewrite this plugin in Kotlin. ([#1012](https://github.com/GradleUp/shadow/pull/1012))

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -13,11 +13,13 @@ public open class ApacheLicenseResourceTransformer : Transformer by NoOpTransfor
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val path = element.relativePath.pathString
     return LICENSE_PATH.equals(path, ignoreCase = true) ||
-      LICENSE_TXT_PATH.regionMatches(0, path, 0, LICENSE_TXT_PATH.length, ignoreCase = true)
+      LICENSE_TXT_PATH.regionMatches(0, path, 0, LICENSE_TXT_PATH.length, ignoreCase = true) ||
+      LICENSE_MD_PATH.regionMatches(0, path, 0, LICENSE_MD_PATH.length, ignoreCase = true)
   }
 
   private companion object {
     private const val LICENSE_PATH = "META-INF/LICENSE"
     private const val LICENSE_TXT_PATH = "META-INF/LICENSE.txt"
+    private const val LICENSE_MD_PATH = "META-INF/LICENSE.md"
   }
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -67,7 +67,9 @@ public open class ApacheNoticeResourceTransformer : Transformer {
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val path = element.relativePath.pathString
-    return NOTICE_PATH.equals(path, ignoreCase = true) || NOTICE_TXT_PATH.equals(path, ignoreCase = true)
+    return NOTICE_PATH.equals(path, ignoreCase = true) ||
+      NOTICE_TXT_PATH.equals(path, ignoreCase = true) ||
+      NOTICE_MD_PATH.equals(path, ignoreCase = true)
   }
 
   override fun transform(context: TransformerContext) {
@@ -174,5 +176,6 @@ public open class ApacheNoticeResourceTransformer : Transformer {
   private companion object {
     private const val NOTICE_PATH = "META-INF/NOTICE"
     private const val NOTICE_TXT_PATH = "META-INF/NOTICE.txt"
+    private const val NOTICE_MD_PATH = "META-INF/NOTICE.md"
   }
 }

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.groovy
@@ -52,6 +52,8 @@ class ApacheLicenseResourceTransformerTest extends TransformerTestSupport<Apache
         assertTrue(transformer.canTransformResource(getFileElement("META-INF/LICENSE")))
         assertTrue(transformer.canTransformResource(getFileElement("META-INF/LICENSE.TXT")))
         assertTrue(transformer.canTransformResource(getFileElement("META-INF/License.txt")))
+        assertTrue(transformer.canTransformResource(getFileElement("META-INF/LICENSE.md")))
+        assertTrue(transformer.canTransformResource(getFileElement("META-INF/License.md")))
         assertFalse(transformer.canTransformResource(getFileElement("META-INF/MANIFEST.MF")))
     }
 

--- a/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformerParameterTests.groovy
+++ b/src/test/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformerParameterTests.groovy
@@ -43,6 +43,15 @@ class ApacheNoticeResourceTransformerParameterTests extends TransformerTestSuppo
     }
 
     @Test
+    void testCanTransformResource() {
+      assertTrue(transformer.canTransformResource(getFileElement("META-INF/NOTICE")))
+      assertTrue(transformer.canTransformResource(getFileElement("META-INF/NOTICE.TXT")))
+      assertTrue(transformer.canTransformResource(getFileElement("META-INF/Notice.txt")))
+      assertTrue(transformer.canTransformResource(getFileElement("META-INF/NOTICE.md")))
+      assertTrue(transformer.canTransformResource(getFileElement("META-INF/Notice.md")))
+    }
+
+    @Test
     void testNoParametersShouldNotThrowNullPointerWhenNoInput() {
         processAndFailOnNullPointer("")
     }


### PR DESCRIPTION
Refs https://github.com/apache/maven-shade-plugin/pull/51.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
