### PR TITLE
Fix PR reference number for removal of Develocity integration

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -29,7 +29,7 @@
 
 **Removed**
 
-- **BREAKING CHANGE:** Remove Develocity integration. ([#1013](https://github.com/GradleUp/shadow/pull/1013))
+- **BREAKING CHANGE:** Remove Develocity integration. ([#1014](https://github.com/GradleUp/shadow/pull/1014))
 
 **Fixed**
 


### PR DESCRIPTION
---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
