### PR TITLE
Move JavaJarExec out of internal

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -227,6 +227,12 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 	public abstract fun inheritFrom ([Ljava/lang/Object;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest;
 }
 
+public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/JavaJarExec : org/gradle/api/tasks/JavaExec {
+	public fun <init> ()V
+	public fun exec ()V
+	public abstract fun getJarFile ()Lorg/gradle/api/file/RegularFileProperty;
+}
+
 public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/KnowsTask : org/gradle/api/DefaultTask {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/tasks/KnowsTask$Companion;
 	public static final field DESC Ljava/lang/String;

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -1,7 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow
 
-import com.github.jengelman.gradle.plugins.shadow.internal.JavaJarExec
 import com.github.jengelman.gradle.plugins.shadow.internal.requireResourceAsText
+import com.github.jengelman.gradle.plugins.shadow.tasks.JavaJarExec
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/JavaJarExec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/JavaJarExec.kt
@@ -1,13 +1,13 @@
-package com.github.jengelman.gradle.plugins.shadow.internal
+package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskAction
 
-internal abstract class JavaJarExec : JavaExec() {
+public abstract class JavaJarExec : JavaExec() {
   @get:InputFile
-  abstract val jarFile: RegularFileProperty
+  public abstract val jarFile: RegularFileProperty
 
   @TaskAction
   override fun exec() {


### PR DESCRIPTION
Users can import the `runShadow` type in their build files.

Refs #1071.