### PR TITLE
Exclude transitive deps from plexus-xml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,10 @@ dependencies {
   implementation(libs.jdependency)
   implementation(libs.jdom2)
   implementation(libs.plexus.utils)
-  implementation(libs.plexus.xml)
+  implementation(libs.plexus.xml) {
+    // We don't need com.apache.maven things from plexus-xml.
+    isTransitive = false
+  }
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)


### PR DESCRIPTION
```
runtimeClasspath - Runtime classpath of 'main'.
+--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0
|    \--- org.jetbrains:annotations:13.0
+--- org.apache.ant:ant:1.10.15
|    \--- org.apache.ant:ant-launcher:1.10.15
+--- commons-io:commons-io:2.18.0
+--- org.apache.logging.log4j:log4j-core:2.24.2
|    \--- org.apache.logging.log4j:log4j-api:2.24.2
+--- org.ow2.asm:asm-commons:9.7.1
|    +--- org.ow2.asm:asm:9.7.1
|    \--- org.ow2.asm:asm-tree:9.7.1
|         \--- org.ow2.asm:asm:9.7.1
+--- org.vafer:jdependency:2.11
+--- org.jdom:jdom2:2.0.6.1
+--- org.codehaus.plexus:plexus-utils:4.0.2
\--- org.codehaus.plexus:plexus-xml:4.0.4
```

```diff
 \--- org.codehaus.plexus:plexus-xml:4.0.4
-     \--- org.apache.maven:maven-xml-impl:4.0.0-alpha-9
-          +--- org.apache.maven:maven-api-xml:4.0.0-alpha-9
-          |    \--- org.apache.maven:maven-api-meta:4.0.0-alpha-9
-          \--- com.fasterxml.woodstox:woodstox-core:6.5.1
-               \--- org.codehaus.woodstox:stax2-api:4.2.1
```

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
