### PR TITLE
Only expose `includes` and `excludes` as inputs in `SimpleRelocator`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -185,17 +185,19 @@ public final class com/github/jengelman/gradle/plugins/shadow/relocation/Relocat
 }
 
 public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator : com/github/jengelman/gradle/plugins/shadow/relocation/Relocator {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Lorg/gradle/api/model/ObjectFactory;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun applyToSourceContent (Ljava/lang/String;)Ljava/lang/String;
 	public fun canRelocateClass (Ljava/lang/String;)Z
 	public fun canRelocatePath (Ljava/lang/String;)Z
 	public fun exclude (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
+	public final fun getExcludes ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getIncludes ()Lorg/gradle/api/provider/ListProperty;
 	public fun include (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
 	public fun relocateClass (Lcom/github/jengelman/gradle/plugins/shadow/relocation/RelocateClassContext;)Ljava/lang/String;
 	public fun relocatePath (Lcom/github/jengelman/gradle/plugins/shadow/relocation/RelocatePathContext;)Ljava/lang/String;

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -196,13 +196,6 @@ public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocat
 	public fun canRelocateClass (Ljava/lang/String;)Z
 	public fun canRelocatePath (Ljava/lang/String;)Z
 	public fun exclude (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
-	public fun getExcludes ()Ljava/util/Set;
-	public fun getIncludes ()Ljava/util/Set;
-	public fun getPathPattern ()Ljava/lang/String;
-	public fun getPattern ()Ljava/lang/String;
-	public fun getRawString ()Z
-	public fun getShadedPathPattern ()Ljava/lang/String;
-	public fun getShadedPattern ()Ljava/lang/String;
 	public fun include (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
 	public fun relocateClass (Lcom/github/jengelman/gradle/plugins/shadow/relocation/RelocateClassContext;)Ljava/lang/String;
 	public fun relocatePath (Lcom/github/jengelman/gradle/plugins/shadow/relocation/RelocatePathContext;)Ljava/lang/String;

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Changed**
+
+- **BREAKING CHANGE:** Some public getters are removed from `SimpleRelocator`, `includes` and `excludes` are exposed as `ListProperty`s. ([#1079](https://github.com/GradleUp/shadow/pull/1079))
+
 **Fixed**
 
 - Adjust property initializations and modifiers in `ShadowJar`. ([#1090](https://github.com/GradleUp/shadow/pull/1090))  

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
@@ -2,6 +2,9 @@ package com.github.jengelman.gradle.plugins.shadow.relocation
 
 import java.util.regex.Pattern
 import org.codehaus.plexus.util.SelectorUtils
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
 
 /**
  * Modified from [org.apache.maven.plugins.shade.relocation.SimpleRelocator.java](https://github.com/apache/maven-shade-plugin/blob/master/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java).
@@ -12,6 +15,7 @@ import org.codehaus.plexus.util.SelectorUtils
  */
 @CacheableRelocator
 public open class SimpleRelocator @JvmOverloads constructor(
+  objectFactory: ObjectFactory,
   pattern: String? = null,
   shadedPattern: String? = null,
   includes: List<String>? = null,
@@ -22,8 +26,12 @@ public open class SimpleRelocator @JvmOverloads constructor(
   private val pathPattern: String
   private val shadedPattern: String
   private val shadedPathPattern: String
-  private val includes = mutableSetOf<String>()
-  private val excludes = mutableSetOf<String>()
+
+  @get:Input
+  public val includes: ListProperty<String> = objectFactory.listProperty(String::class.java)
+
+  @get:Input
+  public val excludes: ListProperty<String> = objectFactory.listProperty(String::class.java)
 
   init {
     if (rawString) {
@@ -47,16 +55,16 @@ public open class SimpleRelocator @JvmOverloads constructor(
         this.shadedPathPattern = shadedPattern.replace('.', '/')
       }
     }
-    this.includes += normalizePatterns(includes)
-    this.excludes += normalizePatterns(excludes)
+    this.includes.addAll(normalizePatterns(includes))
+    this.excludes.addAll(normalizePatterns(excludes))
   }
 
   public open fun include(pattern: String): SimpleRelocator = apply {
-    includes += normalizePatterns(listOf(pattern))
+    includes.addAll(normalizePatterns(listOf(pattern)))
   }
 
   public open fun exclude(pattern: String): SimpleRelocator = apply {
-    excludes += normalizePatterns(listOf(pattern))
+    excludes.addAll(normalizePatterns(listOf(pattern)))
   }
 
   override fun canRelocatePath(path: String): Boolean {
@@ -104,11 +112,11 @@ public open class SimpleRelocator @JvmOverloads constructor(
   }
 
   private fun isIncluded(path: String): Boolean {
-    return includes.isEmpty() || includes.any { SelectorUtils.matchPath(it, path, "/", true) }
+    return includes.get().isEmpty() || includes.get().any { SelectorUtils.matchPath(it, path, "/", true) }
   }
 
   private fun isExcluded(path: String): Boolean {
-    return excludes.any { SelectorUtils.matchPath(it, path, "/", true) }
+    return excludes.get().any { SelectorUtils.matchPath(it, path, "/", true) }
   }
 
   private companion object {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -225,7 +225,7 @@ public abstract class ShadowJar :
     destination: String,
     action: Action<SimpleRelocator>?,
   ): ShadowJar = apply {
-    val relocator = SimpleRelocator(pattern, destination)
+    val relocator = SimpleRelocator(objectFactory, pattern, destination)
     addRelocator(relocator, action)
   }
 
@@ -301,7 +301,7 @@ public abstract class ShadowJar :
             jarFile.entries().toList()
               .filter { it.name.endsWith(".class") && it.name != "module-info.class" }
               .map { it.name.substringBeforeLast('/').replace('/', '.') }
-              .map { SimpleRelocator(it, "$prefix.$it") }
+              .map { SimpleRelocator(objectFactory, it, "$prefix.$it") }
           }
         }
       }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import com.github.jengelman.gradle.plugins.shadow.util.SimpleRelocator
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocatorTest.kt
@@ -132,10 +132,10 @@ class SimpleRelocatorTest {
 
   @Test
   fun testCanRelocateRawString() {
-    var relocator = SimpleRelocator("org/foo", _rawString = true)
+    var relocator = SimpleRelocator("org/foo", rawString = true)
     assertThat(relocator.canRelocatePath("(I)org/foo/bar/Class")).isTrue()
 
-    relocator = SimpleRelocator("^META-INF/org.foo.xml\$", _rawString = true)
+    relocator = SimpleRelocator("^META-INF/org.foo.xml\$", rawString = true)
     assertThat(relocator.canRelocatePath("META-INF/org.foo.xml")).isTrue()
   }
 
@@ -170,11 +170,11 @@ class SimpleRelocatorTest {
 
   @Test
   fun testRelocateRawString() {
-    var relocator = SimpleRelocator("Lorg/foo", "Lhidden/org/foo", _rawString = true)
+    var relocator = SimpleRelocator("Lorg/foo", "Lhidden/org/foo", rawString = true)
     assertThat(relocator.relocatePath("(I)Lorg/foo/bar/Class"))
       .isEqualTo("(I)Lhidden/org/foo/bar/Class")
 
-    relocator = SimpleRelocator("^META-INF/org.foo.xml\$", "META-INF/hidden.org.foo.xml", _rawString = true)
+    relocator = SimpleRelocator("^META-INF/org.foo.xml\$", "META-INF/hidden.org.foo.xml", rawString = true)
     assertThat(relocator.relocatePath("META-INF/org.foo.xml"))
       .isEqualTo("META-INF/hidden.org.foo.xml")
   }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformerTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
 import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
+import com.github.jengelman.gradle.plugins.shadow.util.SimpleRelocator
 import java.io.File
 import java.net.URL
 import java.util.Collections

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Utils.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Utils.kt
@@ -1,6 +1,23 @@
 package com.github.jengelman.gradle.plugins.shadow.util
 
+import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
 import org.gradle.api.model.ObjectFactory
 import org.gradle.testfixtures.ProjectBuilder
 
 val testObjectFactory: ObjectFactory = ProjectBuilder.builder().build().objects
+
+@Suppress("TestFunctionName")
+fun SimpleRelocator(
+  pattern: String? = null,
+  shadedPattern: String? = null,
+  includes: List<String>? = null,
+  excludes: List<String>? = null,
+  rawString: Boolean = false,
+): SimpleRelocator = SimpleRelocator(
+  objectFactory = testObjectFactory,
+  pattern = pattern,
+  shadedPattern = shadedPattern,
+  includes = includes,
+  excludes = excludes,
+  rawString = rawString,
+)


### PR DESCRIPTION
- Reworks #1047.
- Refs https://github.com/GradleUp/shadow/pull/524#discussion_r1865187155.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
