### PR TITLE
Replace deprecated `SelfResolvingDependency` with `FileCollectionDependency`

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -11,6 +11,7 @@
 
 - **BREAKING CHANGE:** Migrate all `ListProperty` usages to `SetProperty`. ([#1103](https://github.com/GradleUp/shadow/pull/1103))  
   Some public `List` parameters are also changed to `Set`.
+- Replace deprecated `SelfResolvingDependency` with `FileCollectionDependency`. ([#1114](https://github.com/GradleUp/shadow/pull/1114))
 
 
 ## [v9.0.0-beta4] (2024-12-06)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.kt
@@ -4,8 +4,8 @@ import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
 import org.vafer.jdependency.Clazzpath
@@ -59,8 +59,8 @@ internal class UnusedTracker private constructor(
             apiJars.addAll(getApiJarsFromProject(dep.dependencyProjectCompat(project)))
             addJar(runtimeConfiguration, dep, apiJars)
           }
-          is SelfResolvingDependency -> {
-            apiJars.addAll(dep.resolve())
+          is FileCollectionDependency -> {
+            apiJars.addAll(dep.files)
           }
           else -> {
             addJar(runtimeConfiguration, dep, apiJars)


### PR DESCRIPTION
https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
