### PR TITLE
Keep the original `IOException` handling in `ShadowCopyAction.execute`

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -118,10 +118,12 @@ public open class ShadowCopyAction internal constructor(
         processTransformers(outputStream)
       }
     } catch (e: IOException) {
-      throw Zip64RequiredException(
-        "${e.cause?.message}\n\nTo build this archive, please enable the zip64 extension.\n" +
-          "See: ${documentationRegistry.getDslRefForProperty(Zip::class.java, "zip64")}",
-      )
+      if (e.cause is Zip64RequiredException) {
+        throw Zip64RequiredException(
+          "${e.cause?.message}\n\nTo build this archive, please enable the zip64 extension.\n" +
+            "See: ${documentationRegistry.getDslRefForProperty(Zip::class.java, "zip64")}",
+        )
+      }
     }
     return WorkResults.didWork(true)
   }


### PR DESCRIPTION
- Follow up #1028.
- Refs #1146.