### PR TITLE
Exclude module-info.class in Multi-Release folders by default

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Added**
+
+- Exclude `module-info.class` in Multi-Release folders by default. ([#1177](https://github.com/GradleUp/shadow/pull/1177))
+
 **Fixed**
 
 - Fix `Log4j2PluginsCacheFileTransformer` not working for merging `Log4j2Plugins.dat` files. ([#1175](https://github.com/GradleUp/shadow/pull/1175))  

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -207,6 +207,8 @@ class JavaPluginTest : BasePluginTest() {
         insert("META-INF/a.DSA", "DSA Signature Block")
         insert("META-INF/a.RSA", "RSA Signature Block")
         insert("META-INF/a.properties", "key=value")
+        insert("META-INF/versions/9/module-info.class", "module myModuleName {}")
+        insert("META-INF/versions/16/module-info.class", "module myModuleName {}")
         insert("module-info.class", "module myModuleName {}")
       }
     }.publish()
@@ -238,6 +240,8 @@ class JavaPluginTest : BasePluginTest() {
         "META-INF/a.SF",
         "META-INF/a.DSA",
         "META-INF/a.RSA",
+        "META-INF/versions/9/module-info.class",
+        "META-INF/versions/16/module-info.class",
         "module-info.class",
       )
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -96,6 +96,8 @@ public abstract class ShadowJavaPlugin @Inject constructor(
         "META-INF/*.SF",
         "META-INF/*.DSA",
         "META-INF/*.RSA",
+        // module-info.class in Multi-Release folders.
+        "META-INF/versions/**/module-info.class",
         "module-info.class",
       )
     }


### PR DESCRIPTION
Closes #729.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
