### PR TITLE
Support overriding `mainClass` provided by `JavaApplication`

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Fixed**
+
+- Support overriding `mainClass` provided by `JavaApplication`. ([#1182](https://github.com/GradleUp/shadow/pull/1182))
+
 
 ## [v9.0.0-beta6] (2025-01-23)
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.exists
 import assertk.assertions.isEqualTo
 import com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin.Companion.SHADOW_INSTALL_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin.Companion.SHADOW_RUN_TASK_NAME
+import com.github.jengelman.gradle.plugins.shadow.util.Issue
 import com.github.jengelman.gradle.plugins.shadow.util.JarPath
 import com.github.jengelman.gradle.plugins.shadow.util.containsEntries
 import com.github.jengelman.gradle.plugins.shadow.util.getContent
@@ -108,6 +109,9 @@ class ApplicationPluginTest : BasePluginTest() {
     commonAssertions(jarPath("build/install/myapp-shadow/lib/myapp-1.0-all.jar"))
   }
 
+  @Issue(
+    "https://github.com/GradleUp/shadow/issues/613",
+  )
   @Test
   fun canOverrideMainClassAttrInManifestBlock() {
     writeMainClass(className = "Main2")

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -155,16 +155,17 @@ abstract class BasePluginTest {
 
   fun writeMainClass(
     withImports: Boolean = false,
+    className: String = "Main",
   ) {
     val imports = if (withImports) "import junit.framework.Test;" else ""
 
-    path("src/main/java/shadow/Main.java").writeText(
+    path("src/main/java/shadow/$className.java").writeText(
       """
         package shadow;
         $imports
-        public class Main {
+        public class $className {
           public static void main(String[] args) {
-            String content = String.format("Hello, World! (%s)", args);
+            String content = String.format("Hello, World! (%s) from $className", args);
             System.out.println(content);
           }
         }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -36,7 +36,10 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
     shadowJar.configure { jar ->
       jar.inputs.property("mainClassName", classNameProvider)
       jar.doFirst {
-        jar.manifest.attributes["Main-Class"] = classNameProvider.get()
+        // Inject the Main-Class attribute if it is not already present.
+        if (!jar.manifest.attributes.contains("Main-Class")) {
+          jar.manifest.attributes["Main-Class"] = classNameProvider.get()
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #613.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
