### PR TITLE
Move `title` configuration in `config.js` to fix default HTML title

### DIFF
--- a/src/docs/.vuepress/config.js
+++ b/src/docs/.vuepress/config.js
@@ -2,6 +2,7 @@ module.exports = {
   base: "/shadow/",
   dest: "build/site",
   ga: "UA-321220-4",
+  title: 'Gradle Shadow Plugin',
   themeConfig: {
     repo: "GradleUp/shadow",
     docsBranch: 'main',
@@ -9,7 +10,6 @@ module.exports = {
     editLinkText: 'Help improve these docs!',
     logo: '/logo+type.svg',
     docsDir: 'src/docs',
-    title: 'Gradle Shadow Plugin',
     nav: [
       { text: 'User Guide', link: '/introduction/' }
     ],


### PR DESCRIPTION
See `view-source:https://gradleup.com/shadow/`

Docs: https://v1.vuepress.vuejs.org/config/#title

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
