### PR TITLE
Add a caching test for `ShadowJar.dependencyFilter`

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -158,6 +158,22 @@ abstract class BasePluginTest {
     return runnerBlock(runner(tasks.toList())).buildAndFail().assertNoDeprecationWarnings()
   }
 
+  fun publishArtifactCD(circular: Boolean = false) {
+    localRepo.module("shadow", "c", "1.0") {
+      buildJar {
+        insert("c.properties", "c")
+      }
+      if (circular) {
+        addDependency("shadow", "d", "1.0")
+      }
+    }.module("shadow", "d", "1.0") {
+      buildJar {
+        insert("d.properties", "d")
+      }
+      addDependency("shadow", "c", "1.0")
+    }.publish()
+  }
+
   fun writeMainClass(
     sourceSet: String = "main",
     withImports: Boolean = false,

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FilteringTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FilteringTest.kt
@@ -296,20 +296,4 @@ class FilteringTest : BasePluginTest() {
       )
     }
   }
-
-  private fun publishArtifactCD(circular: Boolean = false) {
-    localRepo.module("shadow", "c", "1.0") {
-      buildJar {
-        insert("c.properties", "c")
-      }
-      if (circular) {
-        addDependency("shadow", "d", "1.0")
-      }
-    }.module("shadow", "d", "1.0") {
-      buildJar {
-        insert("d.properties", "d")
-      }
-      addDependency("shadow", "c", "1.0")
-    }.publish()
-  }
 }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingTest.kt
@@ -200,4 +200,42 @@ class ShadowJarCachingTest : BaseCachingTest() {
     assertExecutionsAreCachedAndUpToDate()
     assertions()
   }
+
+  @Test
+  fun shadowJarIsCachedCorrectlyAfterDependencyFilterChanged() {
+    publishArtifactCD()
+    projectScriptPath.appendText(
+      """
+        dependencies {
+          implementation 'shadow:d:1.0'
+        }
+      """.trimIndent() + System.lineSeparator(),
+    )
+    val assertions = {
+      assertThat(outputShadowJar).useAll {
+        containsEntries(
+          "c.properties",
+          "d.properties",
+        )
+      }
+    }
+
+    assertFirstExecutionSuccess()
+    assertions()
+    assertExecutionsAreCachedAndUpToDate()
+    assertions()
+
+    projectScriptPath.appendText(
+      """
+        $shadowJar {
+          dependencyFilter = new com.github.jengelman.gradle.plugins.shadow.internal.MinimizeDependencyFilter(project)
+        }
+      """.trimIndent(),
+    )
+
+    assertFirstExecutionSuccess()
+    assertions()
+    assertExecutionsAreCachedAndUpToDate()
+    assertions()
+  }
 }


### PR DESCRIPTION
Follow up #1206.

I missed that we can use `MinimizeDependencyFilter` as the fallback for testing.