### PR TITLE
Revert "Try out ubuntu-24.04-arm on CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-24.04-arm, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         # Always test on the latest version and some LTS.
         java: [ 17, 21, 23 ]
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,7 @@ jobs:
 
   publish-snapshot:
     needs: build
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     if: github.repository == 'GradleUp/shadow' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     if: github.repository == 'GradleUp/shadow'
     permissions:
       contents: write


### PR DESCRIPTION
Failures like https://github.com/GradleUp/shadow/actions/runs/13173107496/job/36766857773 are too annoying!

Reverts GradleUp/shadow#1164.