### PR TITLE
Remove unnecessary `@Internal` in `ComponentsXmlResourceTransformer`

### DIFF
--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.kt
@@ -28,7 +28,7 @@ class ComponentsXmlResourceTransformerTest : BaseTransformerTest<ComponentsXmlRe
     )
     val diff = XMLUnit.compareXML(
       requireResourceAsStream("components-expected.xml").bufferedReader().readText(),
-      transformer.transformedResource.decodeToString(),
+      transformer.getTransformedResource().decodeToString(),
     )
     assertThat(diff.identical()).isTrue()
   }


### PR DESCRIPTION
Refs https://github.com/apache/maven-shade-plugin/blob/3a844d0fa5ad7c283507a274ba1455c1207b9bd6/src/main/java/org/apache/maven/plugins/shade/resource/ComponentsXmlResourceTransformer.java#L142-L160.