### PR TITLE
Correct `AbstractCopyTask.from` usages in functional tests

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -362,21 +362,23 @@ abstract class BasePluginTest {
 
     fun String.toProperties(): Properties = Properties().apply { load(byteInputStream()) }
 
-    fun fromJar(vararg paths: Path): String {
-      return paths.joinToString(System.lineSeparator()) { "from('${it.toUri().toURL().path}')" }
+    fun implementationFiles(vararg paths: Path): String {
+      return paths.joinToString(System.lineSeparator()) { "implementation files('${it.toUri().toURL().path}')" }
     }
 
     inline fun <reified T : Transformer> transform(
-      shadowJarBlock: String = "",
+      dependenciesBlock: String = "",
       transformerBlock: String = "",
     ): String {
       return """
-      $shadowJar {
-        $shadowJarBlock
-        transform(${T::class.java.name}) {
-          $transformerBlock
+        dependencies {
+          $dependenciesBlock
         }
-      }
+        $shadowJar {
+          transform(${T::class.java.name}) {
+            $transformerBlock
+          }
+        }
       """.trimIndent()
     }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/ShadowJarCachingTest.kt
@@ -18,8 +18,8 @@ class ShadowJarCachingTest : BaseCachingTest() {
   fun shadowJarIsCachedCorrectlyWhenCopying() {
     projectScriptPath.appendText(
       """
-        $shadowJar {
-          ${fromJar(artifactAJar, artifactBJar)}
+        dependencies {
+          ${implementationFiles(artifactAJar, artifactBJar)}
         }
       """.trimIndent(),
     )
@@ -29,7 +29,7 @@ class ShadowJarCachingTest : BaseCachingTest() {
     }
 
     val replaced = projectScriptPath.readText().lines()
-      .filterNot { it == fromJar(artifactBJar) }
+      .filterNot { it == implementationFiles(artifactBJar) }
       .joinToString(System.lineSeparator())
     projectScriptPath.writeText(replaced)
 
@@ -43,8 +43,8 @@ class ShadowJarCachingTest : BaseCachingTest() {
   fun shadowJarIsCachedCorrectlyWhenOutputFileIsChanged() {
     projectScriptPath.appendText(
       """
-        $shadowJar {
-          ${fromJar(artifactAJar, artifactBJar)}
+        dependencies {
+          ${implementationFiles(artifactAJar, artifactBJar)}
         }
       """.trimIndent() + System.lineSeparator(),
     )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
@@ -17,14 +17,16 @@ class AppendingTransformerTest : BaseTransformerTest() {
     }
     val config = if (shortSyntax) {
       """
+        dependencies {
+          ${implementationFiles(one, two)}
+        }
         $shadowJar {
-          ${fromJar(one, two)}
           append('$ENTRY_TEST_PROPERTIES')
         }
       """.trimIndent()
     } else {
       transform<AppendingTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           resource = '$ENTRY_TEST_PROPERTIES'
         """.trimIndent(),
@@ -50,22 +52,24 @@ class AppendingTransformerTest : BaseTransformerTest() {
     }
     val config = if (shortSyntax) {
       """
+        dependencies {
+          ${implementationFiles(one, two)}
+        }
         $shadowJar {
-          ${fromJar(one, two)}
           append('resources/$APPLICATION_YML_FILE', '$APPLICATION_YML_SEPARATOR')
           append('resources/config/$APPLICATION_YML_FILE', '$APPLICATION_YML_SEPARATOR')
         }
       """.trimIndent()
     } else {
       val block1 = transform<AppendingTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           resource = 'resources/$APPLICATION_YML_FILE'
           separator = '$APPLICATION_YML_SEPARATOR'
         """.trimIndent(),
       )
       val block2 = transform<AppendingTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           resource = 'resources/config/$APPLICATION_YML_FILE'
           separator = '$APPLICATION_YML_SEPARATOR'

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformerTest.kt
@@ -21,14 +21,16 @@ class GroovyExtensionModuleTransformerTest : BaseTransformerTest() {
   fun groovyExtensionModuleTransformer(shortSyntax: Boolean) {
     val config = if (shortSyntax) {
       """
+        dependencies {
+          ${implementationFiles(buildJarFoo(), buildJarBar())}
+        }
         $shadowJar {
-          ${fromJar(buildJarFoo(), buildJarBar())}
           mergeGroovyExtensionModules()
         }
       """.trimIndent()
     } else {
       transform<GroovyExtensionModuleTransformer>(
-        shadowJarBlock = fromJar(buildJarFoo(), buildJarBar()),
+        dependenciesBlock = implementationFiles(buildJarFoo(), buildJarBar()),
       )
     }
     projectScriptPath.appendText(config)
@@ -42,7 +44,7 @@ class GroovyExtensionModuleTransformerTest : BaseTransformerTest() {
   fun groovyExtensionModuleTransformerWorksForLegacyGroovy() {
     projectScriptPath.appendText(
       transform<GroovyExtensionModuleTransformer>(
-        shadowJarBlock = fromJar(
+        dependenciesBlock = implementationFiles(
           buildJarFoo(PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR),
           buildJarBar(PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR),
         ),

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -14,8 +14,10 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
   fun serviceResourceTransformer(shortSyntax: Boolean) {
     val config = if (shortSyntax) {
       """
+        dependencies {
+          ${implementationFiles(buildJarOne(), buildJarTwo())}
+        }
         $shadowJar {
-          ${fromJar(buildJarOne(), buildJarTwo())}
           mergeServiceFiles {
             exclude 'META-INF/services/com.acme.*'
           }
@@ -23,7 +25,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
       """.trimIndent()
     } else {
       transform<ServiceFileTransformer>(
-        shadowJarBlock = fromJar(buildJarOne(), buildJarTwo()),
+        dependenciesBlock = implementationFiles(buildJarOne(), buildJarTwo()),
         transformerBlock = """
           exclude 'META-INF/services/com.acme.*'
         """.trimIndent(),
@@ -49,14 +51,16 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     }
     val config = if (shortSyntax) {
       """
+        dependencies {
+          ${implementationFiles(one, two)}
+        }
         $shadowJar {
-          ${fromJar(one, two)}
           mergeServiceFiles("META-INF/foo")
         }
       """.trimIndent()
     } else {
       transform<ServiceFileTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           path = 'META-INF/foo'
         """.trimIndent(),
@@ -109,8 +113,10 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
 
     projectScriptPath.appendText(
       """
+        dependencies {
+          ${implementationFiles(one, two)}
+        }
         $shadowJar {
-          ${fromJar(one, two)}
           mergeServiceFiles()
           relocate("org.apache", "myapache") {
             exclude 'org.apache.axis.components.compiler.Jikes'

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -87,7 +87,7 @@ class TransformersTest : BaseTransformerTest() {
     }
     projectScriptPath.appendText(
       transform<Log4j2PluginsCacheFileTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
       ),
     )
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformerTest.kt
@@ -27,7 +27,7 @@ class XmlAppendingTransformerTest : BaseTransformerTest() {
 
     projectScriptPath.appendText(
       transform<XmlAppendingTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           resource = '$xmlEntry'
         """.trimIndent(),
@@ -68,7 +68,7 @@ class XmlAppendingTransformerTest : BaseTransformerTest() {
 
     projectScriptPath.appendText(
       transform<XmlAppendingTransformer>(
-        shadowJarBlock = fromJar(one, two),
+        dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
           resource = '$xmlEntry'
         """.trimIndent(),


### PR DESCRIPTION
Local dependency jars should be included by `implementation` instead of `from`, `from` should copy the input files into the output shadowed jar without any unzipping.

Refs #1233.
