### PR TITLE
Move tracking unused classes logic out of `ShadowCopyAction`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -227,7 +227,7 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 
 public class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction : org/gradle/api/internal/file/copy/CopyAction {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction$Companion;
-	public fun <init> (Ljava/io/File;Lcom/github/jengelman/gradle/plugins/shadow/internal/ZipCompressor;Lorg/gradle/api/internal/DocumentationRegistry;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lorg/gradle/api/tasks/util/PatternSet;Lcom/github/jengelman/gradle/plugins/shadow/ShadowStats;ZZ)V
+	public fun <init> (Ljava/io/File;Lcom/github/jengelman/gradle/plugins/shadow/internal/ZipCompressor;Lorg/gradle/api/internal/DocumentationRegistry;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lorg/gradle/api/tasks/util/PatternSet;Lcom/github/jengelman/gradle/plugins/shadow/ShadowStats;ZLjava/util/Set;)V
 	public fun execute (Lorg/gradle/api/internal/file/copy/CopyActionProcessingStream;)Lorg/gradle/api/tasks/WorkResult;
 }
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -7,6 +7,10 @@
 
 - Mark `Transformer` as throwing `IOException`. ([#1248](https://github.com/GradleUp/shadow/pull/1248))
 
+**Changed**
+
+- **BREAKING CHANGE:** Move tracking unused classes logic out of `ShadowCopyAction`. ([#1257](https://github.com/GradleUp/shadow/pull/1257))
+
 
 ## [v9.0.0-beta8] (2025-02-08)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RealStreamAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RealStreamAction.kt
@@ -32,7 +32,7 @@ internal class RealStreamAction(
   private val transformers: Set<Transformer>,
   private val relocators: Set<Relocator>,
   private val patternSet: PatternSet,
-  private val unused: Set<String>,
+  private val unusedClasses: Set<String>,
   private val stats: ShadowStats,
   private val zipFile: File,
   private val preserveFileTimestamps: Boolean,
@@ -146,7 +146,7 @@ internal class RealStreamAction(
   private fun isUnused(classPath: String): Boolean {
     val classPathWithoutExtension = classPath.substringBeforeLast(".")
     val className = classPathWithoutExtension.replace('/', '.')
-    val result = unused.contains(className)
+    val result = unusedClasses.contains(className)
     if (result) {
       logger.debug("Dropping unused class: $className")
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -273,10 +273,14 @@ public abstract class ShadowJar :
 
   override fun createCopyAction(): CopyAction {
     val documentationRegistry = services.get(DocumentationRegistry::class.java)
-    val unusedTracker = if (minimizeJar.get()) {
-      UnusedTracker.forProject(apiJars, sourceSetsClassesDirs.files, toMinimize)
+    val unusedClasses = if (minimizeJar.get()) {
+      val unusedTracker = UnusedTracker.forProject(apiJars, sourceSetsClassesDirs.files, toMinimize)
+      includedDependencies.files.forEach {
+        unusedTracker.addDependency(it)
+      }
+      unusedTracker.findUnused()
     } else {
-      null
+      emptySet()
     }
     return ShadowCopyAction(
       archiveFile.get().asFile,
@@ -288,8 +292,7 @@ public abstract class ShadowJar :
       rootPatternSet,
       stats,
       isPreserveFileTimestamps,
-      minimizeJar.get(),
-      unusedTracker,
+      unusedClasses,
     )
   }
 


### PR DESCRIPTION
Refs #1233.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
