### PR TITLE
Remove `ShadowJar.rootPatternSet`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -227,7 +227,7 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 
 public class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction : org/gradle/api/internal/file/copy/CopyAction {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction$Companion;
-	public fun <init> (Ljava/io/File;Lcom/github/jengelman/gradle/plugins/shadow/internal/ZipCompressor;Lorg/gradle/api/internal/DocumentationRegistry;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lorg/gradle/api/tasks/util/PatternSet;Lcom/github/jengelman/gradle/plugins/shadow/ShadowStats;ZLjava/util/Set;)V
+	public fun <init> (Ljava/io/File;Lcom/github/jengelman/gradle/plugins/shadow/internal/ZipCompressor;Lorg/gradle/api/internal/DocumentationRegistry;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lcom/github/jengelman/gradle/plugins/shadow/ShadowStats;ZLjava/util/Set;)V
 	public fun execute (Lorg/gradle/api/internal/file/copy/CopyActionProcessingStream;)Lorg/gradle/api/tasks/WorkResult;
 }
 
@@ -289,7 +289,6 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar
 	public fun getMinimizeJar ()Lorg/gradle/api/provider/Property;
 	public fun getRelocationPrefix ()Lorg/gradle/api/provider/Property;
 	public fun getRelocators ()Lorg/gradle/api/provider/SetProperty;
-	protected fun getRootPatternSet ()Lorg/gradle/api/tasks/util/PatternSet;
 	public fun getSourceSetsClassesDirs ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getToMinimize ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getTransformers ()Lorg/gradle/api/provider/SetProperty;

--- a/lint-baseline.xml
+++ b/lint-baseline.xml
@@ -136,17 +136,6 @@
     <issue
         id="InternalGradleApiUsage"
         message="Avoid using internal Gradle APIs"
-        errorLine1="import org.gradle.api.internal.file.copy.DefaultCopySpec"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt"
-            line="38"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="InternalGradleApiUsage"
-        message="Avoid using internal Gradle APIs"
         errorLine1="import org.gradle.api.internal.file.DefaultFileTreeElement"
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -14,6 +14,7 @@
 **Removed**
 
 - **BREAKING CHANGE:** Remove `BaseStreamAction`. ([#1258](https://github.com/GradleUp/shadow/pull/1258))
+- **BREAKING CHANGE:** Remove `ShadowJar.rootPatternSet`. ([#1259](https://github.com/GradleUp/shadow/pull/1259))
 
 
 ## [v9.0.0-beta8] (2025-02-08)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RealStreamAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RealStreamAction.kt
@@ -19,7 +19,6 @@ import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
 import org.gradle.api.logging.Logger
-import org.gradle.api.tasks.util.PatternSet
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.commons.ClassRemapper
@@ -32,7 +31,6 @@ internal class RealStreamAction(
   encoding: String?,
   private val transformers: Set<Transformer>,
   private val relocators: Set<Relocator>,
-  private val patternSet: PatternSet,
   private val unusedClasses: Set<String>,
   private val stats: ShadowStats,
   private val zipFile: File,
@@ -106,9 +104,7 @@ internal class RealStreamAction(
         .map {
           ArchiveFileTreeElement(RelativeArchivePath(it, preserveFileTimestamps))
         }
-        .filter {
-          patternSet.asSpec.isSatisfiedBy(it.asFileTreeElement())
-        }.forEach { archiveElement ->
+        .forEach { archiveElement ->
           if (archiveElement.relativePath.isFile) {
             visitArchiveFile(archiveElement, archive)
           }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -27,7 +27,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.WorkResults
 import org.gradle.api.tasks.bundling.Zip
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * Modified from [org.gradle.api.internal.file.archive.ZipCopyAction.java](https://github.com/gradle/gradle/blob/b893c2b085046677cf858fb3d5ce00e68e556c3a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java).
@@ -39,7 +38,6 @@ public open class ShadowCopyAction(
   private val encoding: String?,
   private val transformers: Set<Transformer>,
   private val relocators: Set<Relocator>,
-  private val patternSet: PatternSet,
   private val stats: ShadowStats,
   private val preserveFileTimestamps: Boolean,
   private val unusedClasses: Set<String>,
@@ -60,7 +58,6 @@ public open class ShadowCopyAction(
             encoding,
             transformers,
             relocators,
-            patternSet,
             unusedClasses,
             stats,
             zipFile,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -35,7 +35,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.copy.CopyAction
-import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
@@ -50,7 +49,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.bundling.ZipEntryCompression
-import org.gradle.api.tasks.util.PatternSet
 
 @CacheableTask
 public abstract class ShadowJar :
@@ -105,10 +103,6 @@ public abstract class ShadowJar :
 
   @get:Internal
   internal val stats: ShadowStats = ShadowStats()
-
-  @get:Internal
-  protected open val rootPatternSet: PatternSet
-    get() = (mainSpec.buildRootResolver() as DefaultCopySpec.DefaultCopySpecResolver).patternSet
 
   @get:Internal
   protected open val internalCompressor: ZipCompressor
@@ -289,7 +283,6 @@ public abstract class ShadowJar :
       metadataCharset,
       transformers.get(),
       relocators.get() + packageRelocators,
-      rootPatternSet,
       stats,
       isPreserveFileTimestamps,
       unusedClasses,


### PR DESCRIPTION
Seems it's unused now.

Refs #1233.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
