### PR TITLE
Correct`inheritFrom` usages in Kotlin DSL

### DIFF
--- a/src/docs/configuration/README.md
+++ b/src/docs/configuration/README.md
@@ -89,15 +89,13 @@ If it is desired to inherit a manifest from a JAR task other than the standard `
 on the `shadowJar.manifest` object can be used to configure the upstream.
 
 ```groovy
-tasks.register('testJar', Jar) {
+def testJar = tasks.register('testJar', Jar) {
   manifest {
     attributes 'Description': 'This is an application JAR'
   }
 }
 
 tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-  manifest {
-    inheritFrom(project.tasks.testJar.manifest)
-  }
+  manifest.inheritFrom(testJar.map { it.manifest })
 }
 ```

--- a/src/docs/configuration/README.md
+++ b/src/docs/configuration/README.md
@@ -96,6 +96,6 @@ def testJar = tasks.register('testJar', Jar) {
 }
 
 tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-  manifest.inheritFrom(testJar.map { it.manifest })
+  manifest.inheritFrom(testJar.get().manifest)
 }
 ```

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -619,4 +619,33 @@ class JavaPluginTest : BasePluginTest() {
       )
     }
   }
+
+  @Test
+  fun canInheritFromOtherManifest() {
+    projectScriptPath.appendText(
+      """
+        jar {
+          manifest {
+            attributes 'Foo-Attr': 'Foo-Value'
+          }
+        }
+        def testJar = tasks.register('testJar', Jar) {
+          manifest {
+            attributes 'Bar-Attr': 'Bar-Value'
+          }
+        }
+        $shadowJar {
+          manifest.inheritFrom(testJar.get().manifest)
+        }
+      """.trimIndent(),
+    )
+
+    run(shadowJarTask)
+
+    assertThat(outputShadowJar).useAll {
+      transform { it.manifest.mainAttributes }.isNotEmpty()
+      getMainAttr("Foo-Attr").isEqualTo("Foo-Value")
+      getMainAttr("Bar-Attr").isEqualTo("Bar-Value")
+    }
+  }
 }


### PR DESCRIPTION
Closes #1260.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
