### PR TITLE
Shorten obtaining relative paths

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-gradlePluginLints = "androidx.lint:lint-gradle:1.0.0-alpha03"
 # Dummy to get renovate updates, the version is used in rootProject build.gradle with spotless.
 ktlint = "com.pinterest.ktlint:ktlint-cli:1.5.0"
 
-junit-bom = "org.junit:junit-bom:5.11.4"
+junit-bom = "org.junit:junit-bom:5.12.0"
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 
 [plugins]

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -192,7 +192,7 @@ public open class ShadowCopyAction(
             if (isTransformable(fileDetails)) {
               transform(fileDetails)
             } else {
-              val mappedPath = remapper.map(fileDetails.relativePath.pathString)
+              val mappedPath = remapper.map(fileDetails.path)
               val entry = zipEntry(mappedPath, preserveFileTimestamps, fileDetails.lastModified) {
                 unixMode = UnixStat.FILE_FLAG or fileDetails.permissions.toUnixNumeric()
               }
@@ -213,7 +213,7 @@ public open class ShadowCopyAction(
     private fun visitDir(dirDetails: FileCopyDetails) {
       try {
         // Trailing slash in name indicates that entry is a directory.
-        val path = dirDetails.relativePath.pathString + "/"
+        val path = dirDetails.path + "/"
         val entry = zipEntry(path, preserveFileTimestamps, dirDetails.lastModified) {
           unixMode = UnixStat.DIR_FLAG or dirDetails.permissions.toUnixNumeric()
         }
@@ -362,7 +362,7 @@ public open class ShadowCopyAction(
 
     private fun transformAndClose(element: FileTreeElement, inputStream: InputStream) {
       inputStream.use { steam ->
-        val mappedPath = remapper.map(element.relativePath.pathString)
+        val mappedPath = remapper.map(element.path)
         transformers.find {
           it.canTransformResource(element)
         }?.transform(
@@ -380,8 +380,8 @@ public open class ShadowCopyAction(
     }
 
     companion object {
-      private val FileCopyDetails.isClass: Boolean get() = relativePath.pathString.endsWith(CLASS_SUFFIX)
-      private val FileCopyDetails.isJar: Boolean get() = relativePath.pathString.endsWith(".jar")
+      private val FileCopyDetails.isClass: Boolean get() = path.endsWith(CLASS_SUFFIX)
+      private val FileCopyDetails.isJar: Boolean get() = path.endsWith(".jar")
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -12,7 +12,7 @@ import org.gradle.api.file.FileTreeElement
 @CacheableTransformer
 public open class ApacheLicenseResourceTransformer : Transformer by NoOpTransformer {
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val path = element.relativePath.pathString
+    val path = element.path
     return LICENSE_PATH.equals(path, ignoreCase = true) ||
       LICENSE_TXT_PATH.regionMatches(0, path, 0, LICENSE_TXT_PATH.length, ignoreCase = true) ||
       LICENSE_MD_PATH.regionMatches(0, path, 0, LICENSE_MD_PATH.length, ignoreCase = true)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -74,7 +74,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
   public open val charsetName: Property<String> = objectFactory.property(Charsets.UTF_8.name())
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val path = element.relativePath.pathString
+    val path = element.path
     return NOTICE_PATH.equals(path, ignoreCase = true) ||
       NOTICE_TXT_PATH.equals(path, ignoreCase = true) ||
       NOTICE_MD_PATH.equals(path, ignoreCase = true)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
@@ -37,7 +37,7 @@ public open class AppendingTransformer @Inject constructor(
   public open val separator: Property<String> = objectFactory.property(DEFAULT_SEPARATOR)
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return resource.orNull.equals(element.relativePath.pathString, ignoreCase = true)
+    return resource.orNull.equals(element.path, ignoreCase = true)
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
@@ -26,7 +26,7 @@ public open class ComponentsXmlResourceTransformer : Transformer {
   private val components = mutableMapOf<String, Xpp3Dom>()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return COMPONENTS_XML_PATH == element.relativePath.pathString
+    return COMPONENTS_XML_PATH == element.path
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
@@ -24,7 +24,7 @@ public open class DontIncludeResourceTransformer @Inject constructor(
   public open val resource: Property<String> = objectFactory.property()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val path = element.relativePath.pathString
+    val path = element.path
     return !resource.orNull.isNullOrEmpty() && path.endsWith(resource.get())
   }
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
@@ -34,7 +34,7 @@ public open class GroovyExtensionModuleTransformer : Transformer {
   private var legacy = true
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val path = element.relativePath.pathString
+    val path = element.path
     if (path == PATH_GROOVY_EXTENSION_MODULE_DESCRIPTOR) {
       // Groovy 2.5+
       legacy = false

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
@@ -35,7 +35,7 @@ public open class Log4j2PluginsCacheFileTransformer : Transformer {
   private val tempRelocators = mutableListOf<Relocator>()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return PLUGIN_CACHE_FILE == element.relativePath.pathString
+    return PLUGIN_CACHE_FILE == element.path
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -31,7 +31,7 @@ public open class ManifestAppenderTransformer @Inject constructor(
   public open val attributes: SetProperty<Pair<String, Comparable<*>>> = objectFactory.setProperty()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return MANIFEST_NAME.equals(element.relativePath.pathString, ignoreCase = true)
+    return MANIFEST_NAME.equals(element.path, ignoreCase = true)
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -43,7 +43,7 @@ public open class ManifestResourceTransformer @Inject constructor(
   public open val manifestEntries: MapProperty<String, Attributes> = objectFactory.mapProperty()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val path = element.relativePath.pathString
+    val path = element.path
     return JarFile.MANIFEST_NAME.equals(path, ignoreCase = true)
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
@@ -129,7 +129,7 @@ public open class PropertiesFileTransformer @Inject constructor(
     val mappings = mappings.get()
     val paths = paths.get()
 
-    val path = element.relativePath.pathString
+    val path = element.path
     if (path in mappings) return true
     for (key in mappings.keys) {
       if (key.toRegex().containsMatchIn(path)) return true

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
@@ -41,7 +41,7 @@ public open class XmlAppendingTransformer @Inject constructor(
   public open val resource: Property<String> = objectFactory.property()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return resource.orNull?.equals(element.relativePath.pathString, ignoreCase = true) == true
+    return resource.orNull?.equals(element.path, ignoreCase = true) == true
   }
 
   override fun transform(context: TransformerContext) {


### PR DESCRIPTION
> Returns the path of this file, relative to the root of the containing file tree. Always uses '/' as the hierarchy
  separator, regardless of platform file separator. Same as calling getRelativePath().getPathString().

Closes #1273.
