### PR TITLE
Rename `Transformer` to `ResourceTransformer`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -234,8 +234,8 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar
 	public synthetic fun relocate (Ljava/lang/String;Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public fun relocate (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar;
 	public synthetic fun relocate (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
-	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar;
-	public synthetic fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
+	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar;
+	public synthetic fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public fun transform (Ljava/lang/Class;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar;
 	public synthetic fun transform (Ljava/lang/Class;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public fun transform (Ljava/lang/Class;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar;
@@ -257,12 +257,12 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 	public abstract fun relocate (Ljava/lang/Class;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public abstract fun relocate (Ljava/lang/String;Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public abstract fun relocate (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
-	public abstract fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
+	public abstract fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public abstract fun transform (Ljava/lang/Class;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 	public abstract fun transform (Ljava/lang/Class;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec;
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> ()V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
@@ -271,7 +271,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicen
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getAddHeader ()Lorg/gradle/api/provider/Property;
@@ -290,7 +290,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNotic
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer$Companion;
 	public static final field DEFAULT_SEPARATOR Ljava/lang/String;
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
@@ -309,7 +309,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Appen
 public abstract interface annotation class com/github/jengelman/gradle/plugins/shadow/transformers/CacheableTransformer : java/lang/annotation/Annotation {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field COMPONENTS_XML_PATH Ljava/lang/String;
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer$Companion;
 	public fun <init> ()V
@@ -322,7 +322,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsX
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer$Companion {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public final fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
@@ -332,7 +332,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/DontInclude
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer$Companion;
 	public static final field KEY_EXTENSION_CLASSES Ljava/lang/String;
 	public static final field KEY_MODULE_NAME Ljava/lang/String;
@@ -352,7 +352,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExten
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer$Companion {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getFile ()Lorg/gradle/api/file/RegularFileProperty;
@@ -363,7 +363,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeReso
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> ()V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun hasTransformedResource ()Z
@@ -371,7 +371,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2Plugi
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun append (Ljava/lang/String;Ljava/lang/Comparable;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer;
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -382,7 +382,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestApp
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun attributes (Ljava/util/Map;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer;
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -394,7 +394,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestRes
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getCharsetName ()Lorg/gradle/api/provider/Property;
@@ -425,7 +425,29 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Prope
 	public final fun from (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer$MergeStrategy;
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer, org/gradle/api/tasks/util/PatternFilterable {
+public abstract interface class com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer$Companion;
+	public abstract fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
+	public static fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;
+	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
+	public abstract fun hasTransformedResource ()Z
+	public abstract fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
+	public abstract fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
+}
+
+public final class com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer$Companion : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
+	public final fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;
+	public fun hasTransformedResource ()Z
+	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
+	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
+}
+
+public final class com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer$DefaultImpls {
+	public static fun getObjectFactory (Lcom/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer;)Lorg/gradle/api/model/ObjectFactory;
+}
+
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer, org/gradle/api/tasks/util/PatternFilterable {
 	public fun <init> ()V
 	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
 	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -447,28 +469,6 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFile
 	public fun setIncludes (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun setPath (Ljava/lang/String;)V
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
-}
-
-public abstract interface class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
-	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer$Companion;
-	public abstract fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
-	public static fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;
-	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
-	public abstract fun hasTransformedResource ()Z
-	public abstract fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
-	public abstract fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
-}
-
-public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$Companion : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
-	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
-	public final fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;
-	public fun hasTransformedResource ()Z
-	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
-	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
-}
-
-public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$DefaultImpls {
-	public static fun getObjectFactory (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Lorg/gradle/api/model/ObjectFactory;
 }
 
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext {
@@ -502,7 +502,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Trans
 	public final fun builder ()Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext$Builder;
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getIgnoreDtd ()Lorg/gradle/api/provider/Property;

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -8,6 +8,11 @@
 - Compat Kotlin Multiplatform plugin. ([#1280](https://github.com/GradleUp/shadow/pull/1280))  
   You still need to manually configure `manifest.attributes` (e.g. `Main-Class` attr) in the `shadowJar` task if necessary.
 
+**Changed**
+
+- **BREAKING CHANGE:** Rename `Transformer` to `ResourceTransformer`. ([#1288](https://github.com/GradleUp/shadow/pull/1288))  
+  Aims to better align with the name of [org.apache.maven.plugins.shade.resource.ResourceTransformer.java](https://github.com/apache/maven-shade-plugin/blob/master/src/main/java/org/apache/maven/plugins/shade/resource/ResourceTransformer.java) and to distinguish itself from [org.gradle.api.Transformer.java](https://docs.gradle.org/current/javadoc/org/gradle/api/Transformer.html).
+
 **Fixed**
 
 - Fix the last modified time of shadowed directories. ([#1277](https://github.com/GradleUp/shadow/pull/1277))

--- a/src/docs/configuration/merging/README.md
+++ b/src/docs/configuration/merging/README.md
@@ -9,14 +9,14 @@ This allows a [`Transformer`](https://gradleup.com/shadow/api/shadow/com.github.
 determine if it should process a particular entry and apply any modifications before writing the stream to the output.
 
 ```groovy
-// Adding a Transformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+// Adding a ResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import javax.annotation.Nonnull
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 
-class MyTransformer implements Transformer {
+class MyTransformer implements ResourceTransformer {
   @Override
   boolean canTransformResource(@Nonnull FileTreeElement element) { return true }
 
@@ -38,14 +38,14 @@ tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
 Additionally, a `Transformer` can accept a `Closure` to configure the provided `Transformer`.
 
 ```groovy
-// Configuring a Transformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+// Configuring a ResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import javax.annotation.Nonnull
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 
-class MyTransformer implements Transformer {
+class MyTransformer implements ResourceTransformer {
   boolean enabled
 
   @Override
@@ -71,14 +71,14 @@ tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
 An instantiated instance of a `Transformer` can also be provided.
 
 ```groovy
-// Adding a Transformer Instance
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+// Adding a ResourceTransformer Instance
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import javax.annotation.Nonnull
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
 
-class MyTransformer implements Transformer {
+class MyTransformer implements ResourceTransformer {
   final boolean enabled
 
   MyTransformer(boolean enabled) {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -10,7 +10,7 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin.Compan
 import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin.Companion.SHADOW_JAR_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.internal.requireResourceAsPath
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.util.AppendableMavenRepository
 import com.github.jengelman.gradle.plugins.shadow.util.JarPath
 import java.io.Closeable
@@ -390,7 +390,7 @@ abstract class BasePluginTest {
       return paths.joinToString(System.lineSeparator()) { "implementation files('${it.toUri().toURL().path}')" }
     }
 
-    inline fun <reified T : Transformer> transform(
+    inline fun <reified T : ResourceTransformer> transform(
       dependenciesBlock: String = "",
       transformerBlock: String = "",
     ): String {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/TransformerCachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/TransformerCachingTest.kt
@@ -13,8 +13,8 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCach
 import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestAppenderTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.XmlAppendingTransformer
 import com.github.jengelman.gradle.plugins.shadow.util.containsEntries
 import com.github.jengelman.gradle.plugins.shadow.util.getContent
@@ -147,7 +147,7 @@ class TransformerCachingTest : BaseCachingTest() {
       """
         $shadowJar {
           // Use Transformer.Companion (no-op) to mock a custom transformer here, it's not cacheable.
-          transform(${Transformer.Companion::class.java.name})
+          transform(${ResourceTransformer.Companion::class.java.name})
         }
       """.trimIndent(),
     )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -113,7 +113,7 @@ class TransformersTest : BaseTransformerTest() {
         }
         $shadowJar {
           // Use Transformer.Companion (no-op) to mock a custom transformer here.
-          transform(${Transformer.Companion::class.java.name})
+          transform(${ResourceTransformer.Companion::class.java.name})
         }
       """.trimIndent(),
     )

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -4,7 +4,7 @@ import com.github.jengelman.gradle.plugins.shadow.internal.RelocatorRemapper
 import com.github.jengelman.gradle.plugins.shadow.internal.cast
 import com.github.jengelman.gradle.plugins.shadow.internal.zipEntry
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import java.io.File
 import java.util.GregorianCalendar
@@ -32,7 +32,7 @@ import org.objectweb.asm.commons.ClassRemapper
 public open class ShadowCopyAction(
   private val zipFile: File,
   private val zosProvider: (File) -> ZipOutputStream,
-  private val transformers: Set<Transformer>,
+  private val transformers: Set<ResourceTransformer>,
   private val relocators: Set<Relocator>,
   private val unusedClasses: Set<String>,
   private val preserveFileTimestamps: Boolean,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -15,9 +15,9 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
 import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer.Companion.create
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer.Companion.create
 import java.io.File
 import java.io.IOException
 import java.util.jar.JarFile
@@ -102,7 +102,7 @@ public abstract class ShadowJar :
   }
 
   @get:Nested
-  public open val transformers: SetProperty<Transformer> = objectFactory.setProperty()
+  public open val transformers: SetProperty<ResourceTransformer> = objectFactory.setProperty()
 
   @get:Nested
   public open val relocators: SetProperty<Relocator> = objectFactory.setProperty()
@@ -158,15 +158,15 @@ public abstract class ShadowJar :
     action?.execute(dependencyFilter.get())
   }
 
-  override fun transform(clazz: Class<Transformer>): ShadowJar {
+  override fun transform(clazz: Class<ResourceTransformer>): ShadowJar {
     return transform(clazz, null)
   }
 
-  override fun <T : Transformer> transform(clazz: Class<T>, action: Action<T>?): ShadowJar = apply {
+  override fun <T : ResourceTransformer> transform(clazz: Class<T>, action: Action<T>?): ShadowJar = apply {
     addTransform(clazz.create(objectFactory), action)
   }
 
-  override fun transform(transformer: Transformer): ShadowJar = apply {
+  override fun transform(transformer: ResourceTransformer): ShadowJar = apply {
     addTransform(transformer, null)
   }
 
@@ -292,7 +292,7 @@ public abstract class ShadowJar :
     relocators.add(relocator)
   }
 
-  private fun <T : Transformer> addTransform(transformer: T, action: Action<T>?) {
+  private fun <T : ResourceTransformer> addTransform(transformer: T, action: Action<T>?) {
     action?.execute(transformer)
     transformers.add(transformer)
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowSpec.kt
@@ -2,9 +2,8 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
-import com.github.jengelman.gradle.plugins.shadow.tasks.DependencyFilter
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 import java.lang.reflect.InvocationTargetException
 import org.gradle.api.Action
 import org.gradle.api.file.CopySpec
@@ -22,7 +21,7 @@ public interface ShadowSpec : CopySpec {
     NoSuchMethodException::class,
     InvocationTargetException::class,
   )
-  public fun transform(clazz: Class<Transformer>): ShadowSpec
+  public fun transform(clazz: Class<ResourceTransformer>): ShadowSpec
 
   @Throws(
     InstantiationException::class,
@@ -30,9 +29,9 @@ public interface ShadowSpec : CopySpec {
     NoSuchMethodException::class,
     InvocationTargetException::class,
   )
-  public fun <T : Transformer> transform(clazz: Class<T>, action: Action<T>?): ShadowSpec
+  public fun <T : ResourceTransformer> transform(clazz: Class<T>, action: Action<T>?): ShadowSpec
 
-  public fun transform(transformer: Transformer): ShadowSpec
+  public fun transform(transformer: ResourceTransformer): ShadowSpec
 
   public fun mergeServiceFiles(): ShadowSpec
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -10,7 +10,7 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ApacheLicenseResourceTransformer : Transformer by Transformer.Companion {
+public open class ApacheLicenseResourceTransformer : ResourceTransformer by ResourceTransformer.Companion {
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val path = element.path
     return LICENSE_PATH.equals(path, ignoreCase = true) ||

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.Optional
 @CacheableTransformer
 public open class ApacheNoticeResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   private val entries = mutableSetOf<String>()
   private val organizationEntries = mutableMapOf<String, MutableSet<String>>()
   private inline val charset get() = Charset.forName(charsetName.get())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.Optional
 @Suppress("ktlint:standard:backing-property-naming")
 public open class AppendingTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   /**
    * Defer initialization, see [issue 763](https://github.com/GradleUp/shadow/issues/763).
    */

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.Internal
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ComponentsXmlResourceTransformer : Transformer {
+public open class ComponentsXmlResourceTransformer : ResourceTransformer {
   private val components = mutableMapOf<String, Xpp3Dom>()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.Optional
 @CacheableTransformer
 public open class DontIncludeResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer by Transformer.Companion {
+) : ResourceTransformer by ResourceTransformer.Companion {
   @get:Optional
   @get:Input
   public open val resource: Property<String> = objectFactory.property()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
@@ -25,7 +25,7 @@ import org.gradle.api.file.FileTreeElement
  * Related to [org.apache.maven.plugins.shade.resource.GroovyResourceTransformer.java](https://github.com/apache/maven-shade-plugin/blob/master/src/main/java/org/apache/maven/plugins/shade/resource/GroovyResourceTransformer.java).
  */
 @CacheableTransformer
-public open class GroovyExtensionModuleTransformer : Transformer {
+public open class GroovyExtensionModuleTransformer : ResourceTransformer {
   private val module = Properties()
 
   /**

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.PathSensitivity
 @CacheableTransformer
 public open class IncludeResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer by Transformer.Companion {
+) : ResourceTransformer by ResourceTransformer.Companion {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NONE)
   public open val file: RegularFileProperty = objectFactory.fileProperty()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
@@ -23,7 +23,7 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 @CacheableTransformer
-public open class Log4j2PluginsCacheFileTransformer : Transformer {
+public open class Log4j2PluginsCacheFileTransformer : ResourceTransformer {
   /**
    * Log4j config files to share across the transformation stages.
    */

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.Input
 @CacheableTransformer
 public open class ManifestAppenderTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   private var manifestContents = ByteArray(0)
 
   @get:Input

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -31,7 +31,7 @@ import org.gradle.api.tasks.Optional
 @CacheableTransformer
 public open class ManifestResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   private var manifestDiscovered = false
   private var manifest: Manifest? = null
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
@@ -6,7 +6,6 @@ import com.github.jengelman.gradle.plugins.shadow.internal.mapProperty
 import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.setProperty
 import com.github.jengelman.gradle.plugins.shadow.internal.zipEntry
-import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer.MergeStrategy
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.util.Properties
@@ -101,7 +100,7 @@ import org.gradle.api.tasks.Internal
 @CacheableTransformer
 public open class PropertiesFileTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   private inline val charset get() = Charset.forName(charsetName.get())
 
   @get:Internal

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
@@ -15,7 +15,7 @@ import org.gradle.api.tasks.Internal
  * @author John Engelman
  */
 @JvmDefaultWithCompatibility
-public interface Transformer {
+public interface ResourceTransformer {
   public fun canTransformResource(element: FileTreeElement): Boolean
 
   @Throws(IOException::class)
@@ -36,11 +36,11 @@ public interface Transformer {
     get() = throw NotImplementedError("You have to make sure this has been implemented or injected.")
 
   /**
-   * This also implements [Transformer] but no-op, which means it could be used by Kotlin delegations.
+   * This also implements [ResourceTransformer] but no-op, which means it could be used by Kotlin delegations.
    */
-  public companion object : Transformer {
+  public companion object : ResourceTransformer {
     @JvmStatic
-    public fun <T : Transformer> Class<T>.create(objectFactory: ObjectFactory): T {
+    public fun <T : ResourceTransformer> Class<T>.create(objectFactory: ObjectFactory): T {
       // If the constructor takes a single ObjectFactory, inject it in.
       val constructor = constructors.find {
         it.parameterTypes.singleOrNull() == ObjectFactory::class.java
@@ -60,7 +60,7 @@ public interface Transformer {
 }
 
 /**
- * Marks that a given instance of [Transformer] is compatible with the Gradle build cache.
+ * Marks that a given instance of [ResourceTransformer] is compatible with the Gradle build cache.
  * In other words, it has its appropriate inputs annotated so that Gradle can consider them when
  * determining the cache key.
  *

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
@@ -28,7 +28,7 @@ public open class ServiceFileTransformer(
   private val patternSet: PatternSet = PatternSet()
     .include(SERVICES_PATTERN)
     .exclude(PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR),
-) : Transformer,
+) : ResourceTransformer,
   PatternFilterable by patternSet {
   @get:Internal
   internal val serviceEntries = mutableMapOf<String, MutableSet<String>>()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
@@ -30,7 +30,7 @@ import org.xml.sax.InputSource
 @CacheableTransformer
 public open class XmlAppendingTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer {
+) : ResourceTransformer {
   private var doc: Document? = null
 
   @get:Input

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
@@ -1,7 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.internal.requireResourceAsStream
-import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer.Companion.create
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer.Companion.create
 import com.github.jengelman.gradle.plugins.shadow.util.noOpDelegate
 import com.github.jengelman.gradle.plugins.shadow.util.testObjectFactory
 import java.lang.reflect.ParameterizedType
@@ -15,7 +15,7 @@ import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.RelativePath
 import org.junit.jupiter.api.BeforeEach
 
-abstract class BaseTransformerTest<T : Transformer> {
+abstract class BaseTransformerTest<T : ResourceTransformer> {
   protected lateinit var transformer: T
     private set
 
@@ -32,7 +32,7 @@ abstract class BaseTransformerTest<T : Transformer> {
   protected companion object {
     const val MANIFEST_NAME: String = "META-INF/MANIFEST.MF"
 
-    fun Transformer.canTransformResource(path: String, isFile: Boolean = true): Boolean {
+    fun ResourceTransformer.canTransformResource(path: String, isFile: Boolean = true): Boolean {
       val element = object : FileTreeElement by noOpDelegate() {
         private val _relativePath = RelativePath.parse(isFile, path)
         override fun getPath(): String = _relativePath.pathString
@@ -49,7 +49,7 @@ abstract class BaseTransformerTest<T : Transformer> {
     }
 
     fun doTransformAndGetTransformedPath(
-      transformer: Transformer,
+      transformer: ResourceTransformer,
       preserveFileTimestamps: Boolean,
     ): Path {
       val testableZipPath = createTempFile("testable-zip-file-", ".jar")


### PR DESCRIPTION
Aims to better align with the name of [org.apache.maven.plugins.shade.resource.ResourceTransformer.java](https://github.com/apache/maven-shade-plugin/blob/master/src/main/java/org/apache/maven/plugins/shade/resource/ResourceTransformer.java) and to distinguish itself from [org.gradle.api.Transformer.java](https://docs.gradle.org/current/javadoc/org/gradle/api/Transformer.html).

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
