### PR TITLE
Remove `Named` from the parents of `Transformer`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -265,7 +265,6 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
 	public fun <init> ()V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
-	public fun getName ()Ljava/lang/String;
 	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
 	public fun hasTransformedResource ()Z
 	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
@@ -326,7 +325,6 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Compo
 public class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
-	public fun getName ()Ljava/lang/String;
 	public final fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
 	public fun getResource ()Lorg/gradle/api/provider/Property;
 	public fun hasTransformedResource ()Z
@@ -358,7 +356,6 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeReso
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getFile ()Lorg/gradle/api/file/RegularFileProperty;
-	public fun getName ()Ljava/lang/String;
 	public final fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
 	public fun getResource ()Lorg/gradle/api/provider/Property;
 	public fun hasTransformedResource ()Z
@@ -460,11 +457,10 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFile
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public abstract interface class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer : org/gradle/api/Named {
+public abstract interface class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer$Companion;
 	public abstract fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public static fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;
-	public fun getName ()Ljava/lang/String;
 	public fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
 	public abstract fun hasTransformedResource ()Z
 	public abstract fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
@@ -476,7 +472,6 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Trans
 }
 
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$DefaultImpls {
-	public static fun getName (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Ljava/lang/String;
 	public static fun getObjectFactory (Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;)Lorg/gradle/api/model/ObjectFactory;
 }
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -12,6 +12,10 @@
 
 - Fix the last modified time of shadowed directories. ([#1277](https://github.com/GradleUp/shadow/pull/1277))
 
+**Removed**
+
+- **BREAKING CHANGE:** Remove `Named` from the parents of `Transformer`. ([#1289](https://github.com/GradleUp/shadow/pull/1289))
+
 
 ## [v9.0.0-beta9] (2025-02-24)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.kt
@@ -3,7 +3,6 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.CacheableRelocator
 import java.io.IOException
 import org.apache.tools.zip.ZipOutputStream
-import org.gradle.api.Named
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
@@ -16,7 +15,7 @@ import org.gradle.api.tasks.Internal
  * @author John Engelman
  */
 @JvmDefaultWithCompatibility
-public interface Transformer : Named {
+public interface Transformer {
   public fun canTransformResource(element: FileTreeElement): Boolean
 
   @Throws(IOException::class)
@@ -26,9 +25,6 @@ public interface Transformer : Named {
 
   @Throws(IOException::class)
   public fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean)
-
-  @Internal
-  override fun getName(): String = this::class.java.simpleName
 
   /**
    * This is used for creating Gradle's lazy properties in the subclass, Shadow's build-in transformers that depend on


### PR DESCRIPTION
It's unused.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/src/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
