### PR TITLE
Move `NoOpTransformer` into the companion object of `Transformer`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -394,14 +394,6 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestRes
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public final class com/github/jengelman/gradle/plugins/shadow/transformers/NoOpTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
-	public static final field INSTANCE Lcom/github/jengelman/gradle/plugins/shadow/transformers/NoOpTransformer;
-	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
-	public fun hasTransformedResource ()Z
-	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
-	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
-}
-
 public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -467,8 +459,12 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/trans
 	public abstract fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$Companion {
+public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$Companion : com/github/jengelman/gradle/plugins/shadow/transformers/Transformer {
+	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public final fun create (Ljava/lang/Class;Lorg/gradle/api/model/ObjectFactory;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/Transformer;
+	public fun hasTransformedResource ()Z
+	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
+	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/Transformer$DefaultImpls {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/TransformerCachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/caching/TransformerCachingTest.kt
@@ -12,9 +12,9 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.IncludeResourceTr
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestAppenderTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer
-import com.github.jengelman.gradle.plugins.shadow.transformers.NoOpTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.XmlAppendingTransformer
 import com.github.jengelman.gradle.plugins.shadow.util.containsEntries
 import com.github.jengelman.gradle.plugins.shadow.util.getContent
@@ -146,8 +146,8 @@ class TransformerCachingTest : BaseCachingTest() {
     projectScriptPath.appendText(
       """
         $shadowJar {
-          // Use NoOpTransformer to mock a custom transformer here, it's not cacheable.
-          transform(${NoOpTransformer::class.java.name}.INSTANCE)
+          // Use Transformer.Companion (no-op) to mock a custom transformer here, it's not cacheable.
+          transform(${Transformer.Companion::class.java.name})
         }
       """.trimIndent(),
     )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -112,8 +112,8 @@ class TransformersTest : BaseTransformerTest() {
           implementation 'my:b:1.0'
         }
         $shadowJar {
-          // Use NoOpTransformer to mock a custom transformer here.
-          transform(${NoOpTransformer::class.java.name}.INSTANCE)
+          // Use Transformer.Companion (no-op) to mock a custom transformer here.
+          transform(${Transformer.Companion::class.java.name})
         }
       """.trimIndent(),
     )

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -10,7 +10,7 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ApacheLicenseResourceTransformer : Transformer by NoOpTransformer {
+public open class ApacheLicenseResourceTransformer : Transformer by Transformer.Companion {
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val path = element.path
     return LICENSE_PATH.equals(path, ignoreCase = true) ||

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.Optional
 @CacheableTransformer
 public open class DontIncludeResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer by NoOpTransformer {
+) : Transformer by Transformer.Companion {
   @get:Optional
   @get:Input
   public open val resource: Property<String> = objectFactory.property()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.PathSensitivity
 @CacheableTransformer
 public open class IncludeResourceTransformer @Inject constructor(
   final override val objectFactory: ObjectFactory,
-) : Transformer by NoOpTransformer {
+) : Transformer by Transformer.Companion {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NONE)
   public open val file: RegularFileProperty = objectFactory.fileProperty()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Transformer.kt
@@ -35,7 +35,10 @@ public interface Transformer {
   public val objectFactory: ObjectFactory
     get() = throw NotImplementedError("You have to make sure this has been implemented or injected.")
 
-  public companion object {
+  /**
+   * This also implements [Transformer] but no-op, which means it could be used by Kotlin delegations.
+   */
+  public companion object : Transformer {
     @JvmStatic
     public fun <T : Transformer> Class<T>.create(objectFactory: ObjectFactory): T {
       // If the constructor takes a single ObjectFactory, inject it in.
@@ -48,6 +51,11 @@ public interface Transformer {
         getDeclaredConstructor().newInstance()
       }
     }
+
+    public override fun canTransformResource(element: FileTreeElement): Boolean = false
+    public override fun transform(context: TransformerContext): Unit = Unit
+    public override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean): Unit = Unit
+    public override fun hasTransformedResource(): Boolean = false
   }
 }
 
@@ -61,10 +69,3 @@ public interface Transformer {
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 public annotation class CacheableTransformer
-
-public object NoOpTransformer : Transformer {
-  public override fun canTransformResource(element: FileTreeElement): Boolean = false
-  public override fun transform(context: TransformerContext): Unit = Unit
-  public override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean): Unit = Unit
-  public override fun hasTransformedResource(): Boolean = false
-}


### PR DESCRIPTION
We can get rid of an explicit public object.
