### PR TITLE
Remove redundant types from function returns

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -349,7 +349,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2Plugi
 
 public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
-	public fun append (Ljava/lang/String;Ljava/lang/Comparable;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer;
+	public fun append (Ljava/lang/String;Ljava/lang/Comparable;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getAttributes ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getObjectFactory ()Lorg/gradle/api/model/ObjectFactory;
@@ -360,7 +360,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestApp
 
 public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
-	public fun attributes (Ljava/util/Map;)Lcom/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer;
+	public fun attributes (Ljava/util/Map;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getMainClass ()Lorg/gradle/api/provider/Property;
 	public fun getManifestEntries ()Lorg/gradle/api/provider/MapProperty;

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -146,8 +146,8 @@ public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocat
 public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter : java/io/Serializable {
 	public abstract fun dependency (Ljava/lang/Object;)Lorg/gradle/api/specs/Spec;
 	public abstract fun dependency (Lorg/gradle/api/artifacts/Dependency;)Lorg/gradle/api/specs/Spec;
-	public abstract fun exclude (Lorg/gradle/api/specs/Spec;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter;
-	public abstract fun include (Lorg/gradle/api/specs/Spec;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter;
+	public abstract fun exclude (Lorg/gradle/api/specs/Spec;)V
+	public abstract fun include (Lorg/gradle/api/specs/Spec;)V
 	public abstract fun project (Ljava/lang/String;)Lorg/gradle/api/specs/Spec;
 	public abstract fun project (Ljava/util/Map;)Lorg/gradle/api/specs/Spec;
 	public abstract fun resolve (Ljava/util/Collection;)Lorg/gradle/api/file/FileCollection;

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -134,11 +134,11 @@ public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocat
 	public fun canRelocateClass (Ljava/lang/String;)Z
 	public fun canRelocatePath (Ljava/lang/String;)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public fun exclude (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
+	public fun exclude (Ljava/lang/String;)V
 	public final fun getExcludes ()Ljava/util/Set;
 	public final fun getIncludes ()Ljava/util/Set;
 	public fun hashCode ()I
-	public fun include (Ljava/lang/String;)Lcom/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator;
+	public fun include (Ljava/lang/String;)V
 	public fun relocateClass-XBGRxQs (Ljava/lang/String;)Ljava/lang/String;
 	public fun relocatePath-bvWaKNU (Ljava/lang/String;)Ljava/lang/String;
 }

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -155,8 +155,12 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 }
 
 public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest : org/gradle/api/java/archives/Manifest {
-	public abstract fun inheritFrom ([Ljava/lang/Object;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest;
-	public abstract fun inheritFrom ([Ljava/lang/Object;Lorg/gradle/api/Action;)Lcom/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest;
+	public fun inheritFrom ([Ljava/lang/Object;)V
+	public abstract fun inheritFrom ([Ljava/lang/Object;Lorg/gradle/api/Action;)V
+}
+
+public final class com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest$DefaultImpls {
+	public static fun inheritFrom (Lcom/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest;[Ljava/lang/Object;)V
 }
 
 public class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction : org/gradle/api/internal/file/copy/CopyAction {

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -9,6 +9,7 @@
   - Return values of `ShadowSpec` functions are changed to `Unit` to avoid confusion.
   - `ShadowSpec` no longer extends `CopySpec`.
   - Overload `relocate`, `transform` and things for better usability in Kotlin.
+- **BREAKING CHANGE:** Remove redundant types from function returning. ([#1308](https://github.com/GradleUp/shadow/pull/1308))
 
 
 ## [v9.0.0-beta10] (2025-03-05)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/AbstractDependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/AbstractDependencyFilter.kt
@@ -35,11 +35,11 @@ internal sealed class AbstractDependencyFilter(
       ?: project.files()
   }
 
-  override fun exclude(spec: Spec<ResolvedDependency>): DependencyFilter = apply {
+  override fun exclude(spec: Spec<ResolvedDependency>) {
     excludeSpecs.add(spec)
   }
 
-  override fun include(spec: Spec<ResolvedDependency>): DependencyFilter = apply {
+  override fun include(spec: Spec<ResolvedDependency>) {
     includeSpecs.add(spec)
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultInheritManifest.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultInheritManifest.kt
@@ -16,14 +16,8 @@ internal class DefaultInheritManifest @JvmOverloads constructor(
 
   override fun inheritFrom(
     vararg inheritPaths: Any,
-  ): InheritManifest {
-    return inheritFrom(inheritPaths = inheritPaths, action = null)
-  }
-
-  override fun inheritFrom(
-    vararg inheritPaths: Any,
     action: Action<*>?,
-  ): InheritManifest = apply {
+  ) {
     val mergeSpec = DefaultManifestMergeSpec()
     mergeSpec.from(*inheritPaths)
     inheritMergeSpecs.add(mergeSpec)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
@@ -84,11 +84,11 @@ public open class SimpleRelocator @JvmOverloads constructor(
     }
   }
 
-  public open fun include(pattern: String): SimpleRelocator = apply {
+  public open fun include(pattern: String) {
     includes.addAll(normalizePatterns(listOf(pattern)))
   }
 
-  public open fun exclude(pattern: String): SimpleRelocator = apply {
+  public open fun exclude(pattern: String) {
     excludes.addAll(normalizePatterns(listOf(pattern)))
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -22,12 +22,12 @@ public interface DependencyFilter : Serializable {
   /**
    * Exclude dependencies that match the provided [spec].
    */
-  public fun exclude(spec: Spec<ResolvedDependency>): DependencyFilter
+  public fun exclude(spec: Spec<ResolvedDependency>)
 
   /**
    * Include dependencies that match the provided [spec].
    */
-  public fun include(spec: Spec<ResolvedDependency>): DependencyFilter
+  public fun include(spec: Spec<ResolvedDependency>)
 
   /**
    * Create a [Spec] that matches the provided project [notation].

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.kt
@@ -3,8 +3,11 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 import org.gradle.api.Action
 import org.gradle.api.java.archives.Manifest
 
+@JvmDefaultWithCompatibility
 public interface InheritManifest : Manifest {
-  public fun inheritFrom(vararg inheritPaths: Any): InheritManifest
+  public fun inheritFrom(vararg inheritPaths: Any) {
+    inheritFrom(inheritPaths = inheritPaths, action = null)
+  }
 
-  public fun inheritFrom(vararg inheritPaths: Any, action: Action<*>?): InheritManifest
+  public fun inheritFrom(vararg inheritPaths: Any, action: Action<*>?)
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -64,7 +64,7 @@ public open class ManifestAppenderTransformer @Inject constructor(
     }
   }
 
-  public open fun append(name: String, value: Comparable<*>): ManifestAppenderTransformer = apply {
+  public open fun append(name: String, value: Comparable<*>) {
     attributes.add(Pair(name, value))
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -81,7 +81,7 @@ public open class ManifestResourceTransformer @Inject constructor(
     manifest!!.write(os)
   }
 
-  public open fun attributes(attributes: Map<String, JarAttribute>): ManifestResourceTransformer = apply {
+  public open fun attributes(attributes: Map<String, JarAttribute>) {
     manifestEntries.putAll(attributes)
   }
 


### PR DESCRIPTION
We don't call them as "builders".

Follow up #1307.