### PR TITLE
Merge dependency and project overloads in `DependencyFilter`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -150,12 +150,9 @@ public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocat
 
 public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter : java/io/Serializable {
 	public abstract fun dependency (Ljava/lang/Object;)Lorg/gradle/api/specs/Spec;
-	public abstract fun dependency (Lorg/gradle/api/artifacts/Dependency;)Lorg/gradle/api/specs/Spec;
 	public abstract fun exclude (Lorg/gradle/api/specs/Spec;)V
 	public abstract fun include (Lorg/gradle/api/specs/Spec;)V
 	public abstract fun project (Ljava/lang/Object;)Lorg/gradle/api/specs/Spec;
-	public abstract fun project (Ljava/lang/String;)Lorg/gradle/api/specs/Spec;
-	public abstract fun project (Ljava/util/Map;)Lorg/gradle/api/specs/Spec;
 	public abstract fun resolve (Ljava/util/Collection;)Lorg/gradle/api/file/FileCollection;
 	public abstract fun resolve (Lorg/gradle/api/artifacts/Configuration;)Lorg/gradle/api/file/FileCollection;
 }

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -20,6 +20,10 @@
 
 - Fix relocation exclusion for file patterns like `kotlin/kotlin.kotlin_builtins`. ([#1313](https://github.com/GradleUp/shadow/pull/1313))
 
+**Removed**
+
+- **BREAKING CHANGE:** Reduce dependency and project overloads in `DependencyFilter`. ([#1328](https://github.com/GradleUp/shadow/pull/1328))
+
 
 ## [v9.0.0-beta10] (2025-03-05)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -2,7 +2,6 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import java.io.Serializable
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.specs.Spec
@@ -35,22 +34,7 @@ public interface DependencyFilter : Serializable {
   public fun project(notation: Any): Spec<ResolvedDependency>
 
   /**
-   * Create a [Spec] that matches the provided project [notation].
-   */
-  public fun project(notation: Map<String, *>): Spec<ResolvedDependency>
-
-  /**
-   * Create a [Spec] that matches the provided project [path].
-   */
-  public fun project(path: String): Spec<ResolvedDependency>
-
-  /**
    * Create a [Spec] that matches the provided [dependencyNotation].
    */
   public fun dependency(dependencyNotation: Any): Spec<ResolvedDependency>
-
-  /**
-   * Create a [Spec] that matches the provided [dependency].
-   */
-  public fun dependency(dependency: Dependency): Spec<ResolvedDependency>
 }


### PR DESCRIPTION
They are merged to accept `Any`.

Follow up #1322.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
