### PR TITLE
No need to make `runShadow` depend on `installShadowDist`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -16,6 +16,7 @@
   - `ShadowSpec` no longer extends `CopySpec`.
   - Overload `relocate`, `transform` and things for better usability in Kotlin.
 - **BREAKING CHANGE:** Remove redundant types from function returning. ([#1308](https://github.com/GradleUp/shadow/pull/1308))
+- `runShadow` no longer depends on `installShadowDist`. ([#1353](https://github.com/GradleUp/shadow/pull/1353))
 
 **Fixed**
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -6,6 +6,7 @@ import assertk.assertThat
 import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin.Companion.SHADOW_INSTALL_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin.Companion.SHADOW_RUN_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin.Companion.SHADOW_JAR_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.internal.requireResourceAsPath
@@ -56,6 +57,7 @@ abstract class BasePluginTest {
   val shadowJarTask = ":$SHADOW_JAR_TASK_NAME"
   val serverShadowJarTask = ":server:$SHADOW_JAR_TASK_NAME"
   val runShadowTask = ":$SHADOW_RUN_TASK_NAME"
+  val installShadowDistTask = ":$SHADOW_INSTALL_TASK_NAME"
   val shadowDistZipTask = ":shadowDistZip"
 
   val projectScriptPath: Path get() = path("build.gradle")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -40,10 +40,7 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
       task.description = "Runs this project as a JVM application using the shadow jar"
       task.group = ApplicationPlugin.APPLICATION_GROUP
 
-      val jarFile = tasks.installShadowDist.zip(tasks.shadowJar) { i, s ->
-        i.destinationDir.resolve("lib/${s.archiveFile.get().asFile.name}")
-      }
-      task.classpath(jarFile)
+      task.classpath = files(tasks.shadowJar)
 
       with(applicationExtension) {
         task.mainModule.set(mainModule)


### PR DESCRIPTION
- Split `installShadowOutputs` from `integrationWithApplicationPluginAndJavaToolchains`.
- Tweak `canOverrideMainClassAttrInManifestBlock`.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
