### PR TITLE
Move the group of `ShadowJar` from shadow to build

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -24,7 +24,6 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugi
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin$Companion;
 	public static final field DISTRIBUTION_NAME Ljava/lang/String;
 	public static final field EXTENSION_NAME Ljava/lang/String;
-	public static final field GROUP_NAME Ljava/lang/String;
 	public static final field SHADOW Ljava/lang/String;
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Changed**
+
+- Move the group of `ShadowJar` from `shadow` to `build`. ([#1355](https://github.com/GradleUp/shadow/pull/1355))
+
 
 ## [v9.0.0-beta11] (2025-03-18)
 

--- a/docs/custom-tasks/README.md
+++ b/docs/custom-tasks/README.md
@@ -9,7 +9,7 @@ dependencies to merge into the output.
 
     ```kotlin
     val testShadowJar by tasks.registering(com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar::class) {
-      group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+      group = LifecycleBasePlugin.BUILD_GROUP
       description = "Create a combined JAR of project and test dependencies"
 
       archiveClassifier = "tests"
@@ -33,7 +33,7 @@ dependencies to merge into the output.
 
     ```groovy
     def testShadowJar = tasks.register('testShadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+      group = LifecycleBasePlugin.BUILD_GROUP
       description = 'Create a combined JAR of project and test dependencies'
 
       archiveClassifier = 'tests'

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -163,7 +163,7 @@ It is possible to publish a custom `ShadowJar` task's output via the [`MavenPubl
     }
 
     val testShadowJar by tasks.registering(com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar::class) {
-      group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+      group = LifecycleBasePlugin.BUILD_GROUP
       description = "Create a combined JAR of project and test dependencies"
       archiveClassifier = "tests"
       from(sourceSets.test.map { it.output })
@@ -196,7 +196,7 @@ It is possible to publish a custom `ShadowJar` task's output via the [`MavenPubl
     }
 
     def testShadowJar = tasks.register('testShadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+      group = LifecycleBasePlugin.BUILD_GROUP
       description = 'Create a combined JAR of project and test dependencies'
       archiveClassifier = 'tests'
       from sourceSets.named('test').map { it.output }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -475,7 +475,7 @@ class JavaPluginTest : BasePluginTest() {
           testImplementation 'junit:junit:3.8.2'
         }
         def $testShadowJarTask = tasks.register('$testShadowJarTask', ${ShadowJar::class.java.name}) {
-          group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+          group = LifecycleBasePlugin.BUILD_GROUP
           description = 'Create a combined JAR of project and test dependencies'
           archiveClassifier = 'tests'
           from sourceSets.named('test').map { it.output }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/PublishingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/PublishingTest.kt
@@ -148,7 +148,7 @@ class PublishingTest : BasePluginTest() {
       publishConfiguration(
         projectBlock = """
           def testShadowJar = tasks.register('testShadowJar', ${ShadowJar::class.java.name}) {
-            group = com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.GROUP_NAME
+            group = LifecycleBasePlugin.BUILD_GROUP
             description = 'Create a combined JAR of project and test dependencies'
             archiveClassifier = 'tests'
             from sourceSets.named('test').map { it.output }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.kt
@@ -21,7 +21,6 @@ public abstract class ShadowBasePlugin : Plugin<Project> {
 
   public companion object {
     public const val SHADOW: String = "shadow"
-    public const val GROUP_NAME: String = SHADOW
     public const val EXTENSION_NAME: String = SHADOW
     public const val CONFIGURATION_NAME: String = SHADOW
     public const val COMPONENT_NAME: String = SHADOW

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 
 public abstract class ShadowJavaPlugin @Inject constructor(
@@ -127,7 +128,7 @@ public abstract class ShadowJavaPlugin @Inject constructor(
       action: Action<ShadowJar>,
     ): TaskProvider<ShadowJar> {
       return tasks.register(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) { task ->
-        task.group = ShadowBasePlugin.GROUP_NAME
+        task.group = LifecycleBasePlugin.BUILD_GROUP
         task.description = "Create a combined JAR of project and runtime dependencies"
         task.archiveClassifier.set("all")
         task.exclude(


### PR DESCRIPTION
Aligns with `Jar`, `SourceJarTask`, and so on.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
