### PR TITLE
No need to silence the compatibility warnings

### DIFF
--- a/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/shadow.convention.publish.gradle.kts
@@ -66,11 +66,3 @@ configurations.configureEach {
     }
   }
 }
-
-publishing.publications.withType<MavenPublication>().configureEach {
-  // We don't care about capabilities being unmappable to Maven
-  suppressPomMetadataWarningsFor(API_ELEMENTS_CONFIGURATION_NAME)
-  suppressPomMetadataWarningsFor(RUNTIME_ELEMENTS_CONFIGURATION_NAME)
-  suppressPomMetadataWarningsFor(JAVADOC_ELEMENTS_CONFIGURATION_NAME)
-  suppressPomMetadataWarningsFor(SOURCES_ELEMENTS_CONFIGURATION_NAME)
-}


### PR DESCRIPTION
Run `diff -r shadow-before/ shadow-after > diff.txt`:

```diff
diff --color -r
shadow-before/com.gradleup.shadow.gradle.plugin/9.0.0-SNAPSHOT/maven-metadata-local.xml
shadow-after/com.gradleup.shadow.gradle.plugin/9.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250327025833</lastUpdated>
---
>     <lastUpdated>20250327030008</lastUpdated>
14c14
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
19c19
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
diff --color -r shadow-before/com.gradleup.shadow.gradle.plugin/maven-metadata-local.xml shadow-after/com.gradleup.shadow.gradle.plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20250327025833</lastUpdated>
---
>     <lastUpdated>20250327030008</lastUpdated>
diff --color -r shadow-before/shadow-gradle-plugin/9.0.0-SNAPSHOT/maven-metadata-local.xml shadow-after/shadow-gradle-plugin/9.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20250327025833</lastUpdated>
---
>     <lastUpdated>20250327030008</lastUpdated>
11a12,16
>         <extension>pom.asc</extension>
>         <value>9.0.0-SNAPSHOT</value>
>         <updated>20250327030008</updated>
>       </snapshotVersion>
>       <snapshotVersion>
15c20
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
18c23,24
<         <extension>module</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar.asc</extension>
20c26
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
23,24c29,30
<         <classifier>javadoc</classifier>
<         <extension>jar.asc</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar</extension>
26c32
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
31c37
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
34c40
<         <extension>jar.asc</extension>
---
>         <extension>module</extension>
36c42
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
39d44
<         <classifier>sources</classifier>
42c47
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
47c52
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
50,51c55,56
<         <classifier>sources</classifier>
<         <extension>jar</extension>
---
>         <classifier>javadoc</classifier>
>         <extension>jar.asc</extension>
53c58
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
58,63c63
<         <updated>20250327025833</updated>
<       </snapshotVersion>
<       <snapshotVersion>
<         <extension>pom.asc</extension>
<         <value>9.0.0-SNAPSHOT</value>
<         <updated>20250327025833</updated>
---
>         <updated>20250327030008</updated>
diff --color -r shadow-before/shadow-gradle-plugin/maven-metadata-local.xml shadow-after/shadow-gradle-plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20250327025833</lastUpdated>
---
>     <lastUpdated>20250327030008</lastUpdated>
```

