### PR TITLE
Bump Kotlin to 2.2.0-Beta1 for Java 24 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
   explicitApi()
   compilerOptions {
     // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
+    @Suppress("DEPRECATION") // TODO: bump apiVersion to 2.0 to match Gradle 9.0
     apiVersion = KotlinVersion.KOTLIN_1_8
     jvmTarget = JvmTarget.JVM_11
     freeCompilerArgs.addAll(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.20"
+kotlin = "2.2.0-Beta1"
 moshi = "1.15.2"
 pluginPublish = "1.3.1"
 


### PR DESCRIPTION
Refs #1356.