### PR TITLE
Don't re-add suppressed Gradle API to `compileOnly` configuration

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -99,16 +99,17 @@ public abstract class ShadowJavaPlugin @Inject constructor(
   }
 
   protected open fun Project.configureJavaGradlePlugin() {
-    plugins.withType(JavaGradlePluginPlugin::class.java).configureEach {
-      // Remove the gradleApi so it isn't merged into the jar file.
-      // This is required because 'java-gradle-plugin' adds gradleApi() to the 'api' configuration.
-      // See https://github.com/gradle/gradle/blob/972c3e5c6ef990dd2190769c1ce31998a9402a79/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L161.
-      configurations.named(JavaPlugin.API_CONFIGURATION_NAME) {
-        it.dependencies.remove(dependencies.gradleApi())
-      }
-      // Compile only gradleApi() to make sure the plugin can compile against Gradle API.
-      configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME) {
-        it.dependencies.add(dependencies.gradleApi())
+    // Running this after evaluation to prevent eager creation of configurations
+    afterEvaluate { project ->
+      plugins.withType(JavaGradlePluginPlugin::class.java).configureEach {
+        val gradleApi = project.dependencies.gradleApi()
+        // Remove the gradleApi so it isn't merged into the jar file.
+        // This is required because 'java-gradle-plugin' adds gradleApi() to the 'api' configuration.
+        // See https://github.com/gradle/gradle/blob/972c3e5c6ef990dd2190769c1ce31998a9402a79/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L161.
+        if (project.configurations.findByName(JavaPlugin.API_CONFIGURATION_NAME)?.dependencies?.remove(gradleApi) == true) {
+          // Compile only gradleApi() to make sure the plugin can compile against Gradle API.
+          project.configurations.findByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)?.dependencies?.add(gradleApi)
+        }
       }
     }
   }


### PR DESCRIPTION
As part of Gradle's experiments with publishing an external Gradle API (gradle/gradle#29483), they are beginning to look at suppressing the local Gradle API dependency that is usually used when the `java-gradle-plugin` plugin is applied. Because of this, though, the current strategy that the Shadow plugin uses to move it from `api` to `compileOnly` doesn't check if it exists to begin with. This PR aims to solve that problem. I've added tests as needed.

Gradle's Plugin Publish plugin has a similar issue which I've gone into detail in gradle/plugin-portal-requests#260.

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
