### PR TITLE
Note the removal of `TransformerContext.getEntryTimestamp`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -147,6 +147,7 @@ Options:
 - **BREAKING CHANGE:** Remove `ShadowStats`. ([#1264](https://github.com/GradleUp/shadow/pull/1264))
 - **BREAKING CHANGE:** Remove `ShadowCopyAction.ArchiveFileTreeElement` and
   `RelativeArchivePath`. ([#1233](https://github.com/GradleUp/shadow/pull/1233))
+- **BREAKING CHANGE:** Remove `TransformerContext.getEntryTimestamp`. ([#1245](https://github.com/GradleUp/shadow/pull/1245))
 
 ## [9.0.0-beta8](https://github.com/GradleUp/shadow/releases/tag/9.0.0-beta8) - 2025-02-08
 


### PR DESCRIPTION
Address https://github.com/GradleUp/shadow/pull/1245#discussion_r2146077499.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
