### PR TITLE
Note the behavior change for `ShadowTask.from`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -142,8 +142,8 @@ Options:
   `com.github.jengelman.gradle.plugins.shadow.tasks`. ([#1272](https://github.com/GradleUp/shadow/pull/1272))
 - **BREAKING CHANGE:** Align the behavior of `ShadowTask.from` with Gradle's `AbstractCopyTask.from`. ([#1233](https://github.com/GradleUp/shadow/pull/1233))  
   In the previous versions, `ShadowTask.from` would always unzip the files before processing them, which caused serial
-  issues that are hard to fix. Now it behaves like Gradle's `AbstractCopyTask.from`, which means it will not unzip the files, only
-  copy the files as-is. If you still want to shadow the unzipped files, try out something like:
+  issues that are hard to fix. Now it behaves like Gradle's `AbstractCopyTask.from`, which means it will not unzip
+  the files, only copy the files as-is. If you still want to shadow the unzipped files, try out something like:
   ```kotlin
     tasks.shadowJar {
       from(zipTree(files('path/to/your/file.zip')))


### PR DESCRIPTION
- Closes #1440.
- Closes #1472.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
