### PR TITLE
Expose Ant as `compile` scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ publishing.publications.withType<MavenPublication>().configureEach {
 
 dependencies {
   compileOnly(libs.kotlin.kmp)
-  implementation(libs.apache.ant)
+  api(libs.apache.ant) // Types from Ant are exposed in the public API.
   implementation(libs.apache.commonsIo)
   implementation(libs.apache.log4j)
   implementation(libs.asm)

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.0.0-beta17...HEAD) - 2025-xx-xx
 
+**Changed**
+
+- Expose Ant as compile scope. ([#1487](https://github.com/GradleUp/shadow/pull/1487))
 
 ## [9.0.0-beta17](https://github.com/GradleUp/shadow/releases/tag/9.0.0-beta17) - 2025-06-18
 


### PR DESCRIPTION
As `org.apache.tools.zip.ZipOutputStream` is exposed in the public APIs:

```api
public class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
	...
}
```

View the scope changes:

```diff
diff --color=auto -r before/shadow-gradle-plugin-9.0.0-SNAPSHOT.module after/shadow-gradle-plugin-9.0.0-SNAPSHOT.module
27a28,36
>       "dependencies": [
>         {
>           "group": "org.apache.ant",
>           "module": "ant",
>           "version": {
>             "requires": "1.10.15"
>           }
>         }
>       ],
85,91d93
<           "group": "org.apache.ant",
<           "module": "ant",
<           "version": {
<             "requires": "1.10.15"
<           }
<         },
<         {
137a140,146
>           }
>         },
>         {
>           "group": "org.apache.ant",
>           "module": "ant",
>           "version": {
>             "requires": "1.10.15"
diff --color=auto -r before/shadow-gradle-plugin-9.0.0-SNAPSHOT.pom after/shadow-gradle-plugin-9.0.0-SNAPSHOT.pom
40c40
<       <scope>runtime</scope>
---
>       <scope>compile</scope>
```

Closes #1487.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
