### PR TITLE
Pin Java release on 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,8 @@ dokka {
   }
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+tasks.withType<JavaCompile>().configureEach {
+  options.release = 11
 }
 
 kotlin {
@@ -47,6 +46,7 @@ kotlin {
     languageVersion = apiVersion
     jvmTarget = JvmTarget.JVM_11
     jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+    freeCompilerArgs.add("-Xjdk-release=11")
   }
 }
 


### PR DESCRIPTION
See
* https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror
* https://github.com/gradle/gradle/issues/34035
* https://github.com/Kotlin/api-guidelines/issues/44

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
