### PR TITLE
Use Java 21 for the build (the target is still Java 11)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,13 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: ${{ matrix.java }}
+          # Setup the selected Java, and configure Java 21 by default
+          java-version: |
+            ${{ matrix.java }}
+            21
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew build
+      # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found
+      - run: ./gradlew -Porg.gradle.java.installations.auto-download=false -PtestJdk=${{ matrix.java }} build
 
   # There's no need to run the update task frequently; the start scripts are typically updated with Gradle releases.
   update-start-scripts:
@@ -61,7 +65,8 @@ jobs:
         with:
           cache-read-only: true
       # TODO: https://github.com/gradle/gradle/issues/22779
-      - run: ./gradlew publishToMavenCentral --no-configuration-cache
+      # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found
+      - run: ./gradlew -Porg.gradle.java.installations.auto-download=false publishToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,19 @@ version = providers.gradleProperty("VERSION_NAME").get()
 group = providers.gradleProperty("GROUP").get()
 description = providers.gradleProperty("POM_DESCRIPTION").get()
 
+// Release artifacts target Java 11; however, some tests require Java 17+
+val testJdk = providers.gradleProperty("testJdk").getOrElse("17")
+
 dokka {
   dokkaPublications.html {
     outputDirectory = rootDir.resolve("docs/api")
+  }
+}
+
+java {
+  toolchain {
+    // Use Java 21 for building the project (a recent LTS) to minimize the chances of bugs in the compiler
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 
@@ -168,6 +178,11 @@ testing.suites {
     targets.configureEach {
       testTask {
         maxParallelForks = Runtime.getRuntime().availableProcessors()
+        javaLauncher.set(
+          javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(testJdk))
+          }
+        )
       }
     }
   }

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -5,6 +5,7 @@
 **Changed**
 
 - Expose Ant as `compile` scope. ([#1488](https://github.com/GradleUp/shadow/pull/1488))
+- Use Java 21 for the build (the target is still Java 11) ([#1491](https://github.com/GradleUp/shadow/pull/1491))
 
 ## [9.0.0-beta17](https://github.com/GradleUp/shadow/releases/tag/9.0.0-beta17) - 2025-06-18
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ pluginManagement {
 
 plugins {
   id("com.gradle.develocity") version "4.0.2"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 develocity {


### PR DESCRIPTION
- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
