### PR TITLE
Disable lint tasks on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.plugins.JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.JAVADOC_ELEMENTS_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.SOURCES_ELEMENTS_CONFIGURATION_NAME
-import org.gradle.kotlin.dsl.kotlin
+import org.jetbrains.kotlin.daemon.common.OSKind
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -227,6 +227,13 @@ tasks.pluginUnderTestMetadata {
 tasks.validatePlugins {
   // TODO: https://github.com/gradle/gradle/issues/22600
   enableStricterValidation = true
+}
+
+tasks.whenTaskAdded {
+  if (name.contains("lint") && this::class.java.name.contains("com.android.build")) {
+    // Disable lint tasks for Windows due to ExceptionInInitializerError.
+    enabled = OSKind.current != OSKind.Windows
+  }
 }
 
 tasks.check {


### PR DESCRIPTION
```
Failed
A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintTask$AndroidLintLauncherWorkAction
> There was a failure while executing work items
   > A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
      > java.lang.ExceptionInInitializerError (no error message)

...

Caused by: java.lang.RuntimeException: Could not find installation home path. Please make sure product-info.json is present in the installation directory.
  at com.intellij.openapi.application.PathManager.getHomePath(PathManager.java:113)
  at com.intellij.openapi.application.PathManager.getHomePath(PathManager.java:82)
  at com.intellij.openapi.application.PathManager.getConfigPath(PathManager.java:368)
  at com.intellij.openapi.application.PathManager.getConfigDir(PathManager.java:356)
  at com.intellij.openapi.util.registry.EarlyAccessRegistryManagerKt.configFile_delegate$lambda$0(EarlyAccessRegistryManager.kt:27)
  at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
  at com.intellij.openapi.util.registry.EarlyAccessRegistryManagerKt.getConfigFile(EarlyAccessRegistryManager.kt:26)
  at com.intellij.openapi.util.registry.EarlyAccessRegistryManagerKt.lazyMap$lambda$2(EarlyAccessRegistryManager.kt:33)
  at com.intellij.util.concurrency.SynchronizedClearableLazy._get_value_$lambda$1$lambda$0(SynchronizedClearableLazy.kt:41)
  at com.intellij.util.concurrency.SynchronizedClearableLazy.getValue(SynchronizedClearableLazy.kt:40)
  at com.intellij.openapi.util.registry.EarlyAccessRegistryManager.getString(EarlyAccessRegistryManager.kt:84)
  at com.intellij.openapi.util.registry.EarlyAccessRegistryManager.getBoolean(EarlyAccessRegistryManager.kt:75)
  at com.intellij.ide.plugins.DisabledPluginsState.<clinit>(DisabledPluginsState.kt:32)
  at com.intellij.ide.plugins.PluginEnabler.<clinit>(PluginEnabler.java:22)
  at com.intellij.core.CoreApplicationEnvironment.<init>(CoreApplicationEnvironment.java:84)
  at com.intellij.core.JavaCoreApplicationEnvironment.<init>(JavaCoreApplicationEnvironment.java:47)
  at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment.<init>(KotlinCoreApplicationEnvironment.kt:44)
  at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment.<init>(KotlinCoreApplicationEnvironment.kt)
  at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment$Companion.create(KotlinCoreApplicationEnvironment.kt:113)
  at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createApplicationEnvironment(KotlinCoreEnvironment.kt:678)
  at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.getOrCreateApplicationEnvironment(KotlinCoreEnvironment.kt:563)
  at org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory.createProjectEnvironment(StandaloneProjectFactory.kt:81)
  at org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISessionBuilder.<init>(StandaloneAnalysisAPISessionBuilder.kt:74)
  at com.android.tools.lint.FirUastEnvironmentKt.createAnalysisSession(FirUastEnvironment.kt:210)
  at com.android.tools.lint.FirUastEnvironmentKt.access$createAnalysisSession(FirUastEnvironment.kt:1)
  at com.android.tools.lint.FirUastEnvironment$Companion.create(FirUastEnvironment.kt:92)
  at com.android.tools.lint.UastEnvironment$Companion.create(UastEnvironment.kt:173)
  at com.android.tools.lint.LintCliClient.initializeProjects(LintCliClient.kt:1411)
  at com.android.tools.lint.client.api.LintClient.performInitializeProjects$lint_api(LintClient.kt:1011)
  at com.android.tools.lint.client.api.LintDriver.initializeProjectRoots(LintDriver.kt:570)
  at com.android.tools.lint.client.api.LintDriver.doAnalyze(LintDriver.kt:485)
  at com.android.tools.lint.client.api.LintDriver.doAnalyze$default(LintDriver.kt:479)
  at com.android.tools.lint.client.api.LintDriver.mergeOnly(LintDriver.kt:465)
  at com.android.tools.lint.LintCliClient$mergeOnly$1.invoke(LintCliClient.kt:302)
  at com.android.tools.lint.LintCliClient$mergeOnly$1.invoke(LintCliClient.kt:299)
  at com.android.tools.lint.LintCliClient.run(LintCliClient.kt:330)
  at com.android.tools.lint.LintCliClient.mergeOnly(LintCliClient.kt:299)
  at com.android.tools.lint.Main.run(Main.java:1775)
  at com.android.tools.lint.Main.run(Main.java:283)
  at com.android.build.gradle.internal.lint.AndroidLintWorkAction.invokeLintMainRunMethod(AndroidLintWorkAction.kt:103)
  at com.android.build.gradle.internal.lint.AndroidLintWorkAction.runLint(AndroidLintWorkAction.kt:90)
  at com.android.build.gradle.internal.lint.AndroidLintWorkAction.execute(AndroidLintWorkAction.kt:64)
  at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:68)
  at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
  at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
  at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
  at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
  at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
  at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
  at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
  at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
  at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
  at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
  at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
  at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
  at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
  at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
  at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
  at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:176)
  at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:194)
  at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:127)
  at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:169)
  at org.gradle.internal.Factories$1.create(Factories.java:31)
  at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
  at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
  at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:132)
  at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:164)
  at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:133)
  at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
  at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
```
