### PR TITLE
Rename `enableRelocation` to `enableAutoRelocation` and CLI option cleanups

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -203,7 +203,7 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar
 	protected abstract fun getArchiveOperations ()Lorg/gradle/api/file/ArchiveOperations;
 	public fun getConfigurations ()Lorg/gradle/api/provider/SetProperty;
 	public fun getDependencyFilter ()Lorg/gradle/api/provider/Property;
-	public fun getEnableRelocation ()Lorg/gradle/api/provider/Property;
+	public fun getEnableAutoRelocation ()Lorg/gradle/api/provider/Property;
 	public fun getExcludes ()Ljava/util/Set;
 	public fun getIncludedDependencies ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getIncludes ()Ljava/util/Set;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -177,8 +177,8 @@
 ```
 Options:
 
---enable-relocation       Enable relocation of packages in the jar
---no-enable-relocation    Disables option --enable-relocation
+--enable-auto-relocation       Enable relocation of packages in the jar
+--no-enable-relocation    Disables option --enable-auto-relocation
 --minimize-jar            Minimize the jar by removing unused classes
 --no-minimize-jar         Disables option --minimize-jar
 --relocation-prefix       Prefix to use for relocated packages
@@ -552,7 +552,7 @@ For example, `classpath("com.github.johnrengelman:shadow:8.1.0")` is the correct
 
 **BREAKING CHANGE:** The `ConfigureShadowRelocation` task was removed as of this version to better support Gradle
 configuration caching.
-Instead, use the `enableRelocation = true` and `relocationPrefix = "<new package>"` settings on the `ShadowJar` task
+Instead, use the `enableAutoRelocation = true` and `relocationPrefix = "<new package>"` settings on the `ShadowJar` task
 type.
 
 ### What's Changed

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -8,12 +8,12 @@
 - **BREAKING CHANGE:** Rename `ShadowJar`'s `enableRelocation` to `enableAutoRelocation`. ([#1541](https://github.com/GradleUp/shadow/pull/1541))  
   The Command Line options are also updated:
   ```
-  --enable-auto-relocation      Enables auto relocation of packages in the dependencies
-  --no-enable-auto-relocation   Disables option --enable-auto-relocation
-  --minimize-jar                Minimizes the jar by removing unused classes
-  --no-minimize-jar             Disables option --minimize-jar
-  --relocation-prefix           Prefix to use for relocated packages
-  --rerun                       Causes the task to be re-run even if up-to-date
+  --enable-auto-relocation      Enables auto relocation of packages in the dependencies.
+  --no-enable-auto-relocation   Disables option --enable-auto-relocation.
+  --minimize-jar                Minimizes the jar by removing unused classes.
+  --no-minimize-jar             Disables option --minimize-jar.
+  --relocation-prefix           Prefix used for auto relocation of packages in the dependencies.
+  --rerun                       Causes the task to be re-run even if up-to-date.
   ```
 
 ## [9.0.0-rc2](https://github.com/GradleUp/shadow/releases/tag/9.0.0-rc2) - 2025-07-23
@@ -189,7 +189,7 @@
 ```
 Options:
 
---enable-relocation       Enables relocation of packages in the jar
+--enable-relocation       Enable relocation of packages in the jar
 --no-enable-relocation    Disables option --enable-relocation
 --minimize-jar            Minimize the jar by removing unused classes
 --no-minimize-jar         Disables option --minimize-jar
@@ -564,7 +564,7 @@ For example, `classpath("com.github.johnrengelman:shadow:8.1.0")` is the correct
 
 **BREAKING CHANGE:** The `ConfigureShadowRelocation` task was removed as of this version to better support Gradle
 configuration caching.
-Instead, use the `enableAutoRelocation = true` and `relocationPrefix = "<new package>"` settings on the `ShadowJar` task
+Instead, use the `enableRelocation = true` and `relocationPrefix = "<new package>"` settings on the `ShadowJar` task
 type.
 
 ### What's Changed

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,18 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.0.0-rc2...HEAD) - 2025-xx-xx
 
+**Changed**
+
+- **BREAKING CHANGE:** Rename `ShadowJar`'s `enableRelocation` to `enableAutoRelocation`. ([#1541](https://github.com/GradleUp/shadow/pull/1541))  
+  The Command Line options are also updated:
+  ```
+  --enable-auto-relocation      Enables auto relocation of packages in the dependencies
+  --no-enable-auto-relocation   Disables option --enable-auto-relocation
+  --minimize-jar                Minimizes the jar by removing unused classes
+  --no-minimize-jar             Disables option --minimize-jar
+  --relocation-prefix           Prefix to use for relocated packages
+  --rerun                       Causes the task to be re-run even if up-to-date
+  ```
 
 ## [9.0.0-rc2](https://github.com/GradleUp/shadow/releases/tag/9.0.0-rc2) - 2025-07-23
 
@@ -177,8 +189,8 @@
 ```
 Options:
 
---enable-auto-relocation       Enable relocation of packages in the jar
---no-enable-relocation    Disables option --enable-auto-relocation
+--enable-relocation       Enables relocation of packages in the jar
+--no-enable-relocation    Disables option --enable-relocation
 --minimize-jar            Minimize the jar by removing unused classes
 --no-minimize-jar         Disables option --minimize-jar
 --relocation-prefix       Prefix to use for relocated packages

--- a/docs/configuration/relocation/README.md
+++ b/docs/configuration/relocation/README.md
@@ -156,14 +156,14 @@ Shadow is shipped with a task that can be used to automatically configure all pa
 relocated. This feature was formally shipped into a 2nd plugin (`com.github.johnrengelman.plugin-shadow`) but has been
 removed for clarity reasons in version 4.0.0.
 
-To configure automatic dependency relocation, set `enableRelocation = true` and optionally specify a custom
+To configure automatic dependency relocation, set `enableAutoRelocation = true` and optionally specify a custom
 `relocationPrefix` to override the default value of `"shadow"`.
 
 === "Kotlin"
 
     ```kotlin
     tasks.shadowJar {
-      enableRelocation = true
+      enableAutoRelocation = true
       relocationPrefix = "myapp"
     }
     ```
@@ -172,7 +172,7 @@ To configure automatic dependency relocation, set `enableRelocation = true` and 
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      enableRelocation = true
+      enableAutoRelocation = true
       relocationPrefix = "myapp"
     }
     ```

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -148,12 +148,12 @@ build script. Passing property values on the command line is particularly helpfu
 Here are the options that can be passed to the `shadowJar`:
 
 ```
---enable-auto-relocation      Enable auto relocation of packages in the dependencies
---no-enable-auto-relocation   Disables option --enable-auto-relocation
---minimize-jar                Minimizes the jar by removing unused classes
---no-minimize-jar             Disables option --minimize-jar
---relocation-prefix           Prefix used for auto relocation of packages in the dependencies
---rerun                       Causes the task to be re-run even if up-to-date
+--enable-auto-relocation      Enable auto relocation of packages in the dependencies.
+--no-enable-auto-relocation   Disables option --enable-auto-relocation.
+--minimize-jar                Minimizes the jar by removing unused classes.
+--no-minimize-jar             Disables option --minimize-jar.
+--relocation-prefix           Prefix used for auto relocation of packages in the dependencies.
+--rerun                       Causes the task to be re-run even if up-to-date.
 ```
 
 Also, you can view more information about the [`ShadowJar`][ShadowJar] task by running the following command:

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -148,12 +148,12 @@ build script. Passing property values on the command line is particularly helpfu
 Here are the options that can be passed to the `shadowJar`:
 
 ```
---enable-relocation       Enable relocation of packages in the jar
---no-enable-relocation    Disables option --enable-relocation
---minimize-jar            Minimize the jar by removing unused classes
---no-minimize-jar         Disables option --minimize-jar
---relocation-prefix       Prefix to use for relocated packages
---rerun                   Causes the task to be re-run even if up-to-date
+--enable-auto-relocation       Enable auto relocation of packages in the dependencies
+--no-enable-auto-relocation    Disables option --enable-auto-relocation
+--minimize-jar                 Minimize the jar by removing unused classes
+--no-minimize-jar              Disables option --minimize-jar
+--relocation-prefix            Prefix used for auto relocation of packages in the dependencies
+--rerun                        Causes the task to be re-run even if up-to-date
 ```
 
 Also, you can view more information about the [`ShadowJar`][ShadowJar] task by running the following command:

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -148,12 +148,12 @@ build script. Passing property values on the command line is particularly helpfu
 Here are the options that can be passed to the `shadowJar`:
 
 ```
---enable-auto-relocation       Enable auto relocation of packages in the dependencies
---no-enable-auto-relocation    Disables option --enable-auto-relocation
---minimize-jar                 Minimize the jar by removing unused classes
---no-minimize-jar              Disables option --minimize-jar
---relocation-prefix            Prefix used for auto relocation of packages in the dependencies
---rerun                        Causes the task to be re-run even if up-to-date
+--enable-auto-relocation      Enable auto relocation of packages in the dependencies
+--no-enable-auto-relocation   Disables option --enable-auto-relocation
+--minimize-jar                Minimizes the jar by removing unused classes
+--no-minimize-jar             Disables option --minimize-jar
+--relocation-prefix           Prefix used for auto relocation of packages in the dependencies
+--rerun                       Causes the task to be re-run even if up-to-date
 ```
 
 Also, you can view more information about the [`ShadowJar`][ShadowJar] task by running the following command:

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -148,7 +148,7 @@ build script. Passing property values on the command line is particularly helpfu
 Here are the options that can be passed to the `shadowJar`:
 
 ```
---enable-auto-relocation      Enable auto relocation of packages in the dependencies.
+--enable-auto-relocation      Enables auto relocation of packages in the dependencies.
 --no-enable-auto-relocation   Disables option --enable-auto-relocation.
 --minimize-jar                Minimizes the jar by removing unused classes.
 --no-minimize-jar             Disables option --minimize-jar.

--- a/docs/gradle-plugins/README.md
+++ b/docs/gradle-plugins/README.md
@@ -29,7 +29,7 @@ task for relocation.
     }
 
     tasks.shadowJar {
-      enableRelocation = true
+      enableAutoRelocation = true
       archiveClassifier = ""
     }
     ```
@@ -52,7 +52,7 @@ task for relocation.
     }
 
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      enableRelocation = true
+      enableAutoRelocation = true
       archiveClassifier = ''
     }
     ```

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -103,11 +103,11 @@ class JavaPluginTest : BasePluginTest() {
     val result = run("help", "--task", shadowJarTask)
 
     assertThat(result.output).contains(
-      "--enable-auto-relocation     Enables auto relocation of packages in the dependencies",
-      "--no-enable-auto-relocation     Disables option --enable-auto-relocation",
-      "--minimize-jar     Minimizes the jar by removing unused classes",
-      "--no-minimize-jar     Disables option --minimize-jar",
-      "--relocation-prefix     Prefix used for auto relocation of packages in the dependencies",
+      "--enable-auto-relocation     Enables auto relocation of packages in the dependencies.",
+      "--no-enable-auto-relocation     Disables option --enable-auto-relocation.",
+      "--minimize-jar     Minimizes the jar by removing unused classes.",
+      "--no-minimize-jar     Disables option --minimize-jar.",
+      "--relocation-prefix     Prefix used for auto relocation of packages in the dependencies.",
     )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -103,11 +103,11 @@ class JavaPluginTest : BasePluginTest() {
     val result = run("help", "--task", shadowJarTask)
 
     assertThat(result.output).contains(
-      "--enable-auto-relocation     Enable relocation of packages in the jar",
-      "--no-enable-relocation     Disables option --enable-auto-relocation",
-      "--minimize-jar     Minimize the jar by removing unused classes",
-      " --no-minimize-jar     Disables option --minimize-jar",
-      "--relocation-prefix     Prefix to use for relocated packages",
+      "--enable-auto-relocation     Enables auto relocation of packages in the dependencies",
+      "--no-enable-auto-relocation     Disables option --enable-auto-relocation",
+      "--minimize-jar     Minimizes the jar by removing unused classes",
+      "--no-minimize-jar     Disables option --minimize-jar",
+      "--relocation-prefix     Prefix used for auto relocation of packages in the dependencies",
     )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginTest.kt
@@ -87,7 +87,7 @@ class JavaPluginTest : BasePluginTest() {
     // Check self properties.
     with(shadowTask) {
       assertThat(minimizeJar.get()).isFalse()
-      assertThat(enableRelocation.get()).isFalse()
+      assertThat(enableAutoRelocation.get()).isFalse()
       assertThat(relocationPrefix.get()).isEqualTo(ShadowBasePlugin.SHADOW)
       assertThat(configurations.get()).all {
         isNotEmpty()
@@ -103,8 +103,8 @@ class JavaPluginTest : BasePluginTest() {
     val result = run("help", "--task", shadowJarTask)
 
     assertThat(result.output).contains(
-      "--enable-relocation     Enable relocation of packages in the jar",
-      "--no-enable-relocation     Disables option --enable-relocation",
+      "--enable-auto-relocation     Enable relocation of packages in the jar",
+      "--no-enable-relocation     Disables option --enable-auto-relocation",
       "--minimize-jar     Minimize the jar by removing unused classes",
       " --no-minimize-jar     Disables option --minimize-jar",
       "--relocation-prefix     Prefix to use for relocated packages",

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
@@ -35,7 +35,7 @@ class RelocationTest : BasePluginTest() {
           implementation 'junit:junit:3.8.2'
         }
         $shadowJar {
-          enableRelocation = true
+          enableAutoRelocation = true
           relocationPrefix = '$relocationPrefix'
         }
       """.trimIndent(),
@@ -357,7 +357,7 @@ class RelocationTest : BasePluginTest() {
 
   @ParameterizedTest
   @MethodSource("preserveLastModifiedProvider")
-  fun preserveLastModifiedCorrectly(enableRelocation: Boolean, preserveFileTimestamps: Boolean) {
+  fun preserveLastModifiedCorrectly(enableAutoRelocation: Boolean, preserveFileTimestamps: Boolean) {
     // Minus 3 sec to avoid the time difference between the file system and the JVM.
     val currentTimeMillis = System.currentTimeMillis() - 3.seconds.inWholeMilliseconds
     val junitEntryTimeRange = junitRawEntries.map { it.time }.let { it.min()..it.max() }
@@ -368,7 +368,7 @@ class RelocationTest : BasePluginTest() {
           implementation 'junit:junit:3.8.2'
         }
         $shadowJar {
-          enableRelocation = $enableRelocation
+          enableAutoRelocation = $enableAutoRelocation
           preserveFileTimestamps = $preserveFileTimestamps
         }
       """.trimIndent(),
@@ -376,7 +376,7 @@ class RelocationTest : BasePluginTest() {
 
     run(shadowJarTask)
 
-    if (enableRelocation) {
+    if (enableAutoRelocation) {
       val (relocatedEntries, otherEntries) = outputShadowJar.use {
         it.entries().toList().partition { entry -> entry.name.startsWith("shadow/") }
       }
@@ -544,7 +544,7 @@ class RelocationTest : BasePluginTest() {
 
   @ParameterizedTest
   @MethodSource("relocationCliOptionProvider")
-  fun enableRelocationByCliOption(enableRelocation: Boolean, relocationPrefix: String) {
+  fun enableAutoRelocationByCliOption(enableAutoRelocation: Boolean, relocationPrefix: String) {
     val mainClassEntry = writeClass()
     projectScriptPath.appendText(
       """
@@ -557,14 +557,14 @@ class RelocationTest : BasePluginTest() {
       .filterNot { it.startsWith("$relocationPrefix/META-INF/") }
       .toTypedArray()
 
-    if (enableRelocation) {
-      run(shadowJarTask, "--enable-relocation", "--relocation-prefix=$relocationPrefix")
+    if (enableAutoRelocation) {
+      run(shadowJarTask, "--enable-auto-relocation", "--relocation-prefix=$relocationPrefix")
     } else {
       run(shadowJarTask, "--relocation-prefix=$relocationPrefix")
     }
 
     assertThat(outputShadowJar).useAll {
-      if (enableRelocation) {
+      if (enableAutoRelocation) {
         containsOnly(
           "my/",
           "$relocationPrefix/",

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -135,21 +135,25 @@ public abstract class ShadowJar :
   }
 
   /**
-   * Enable relocation of packages in the jar.
+   * Enable auto relocation of packages in the dependencies.
    *
    * Defaults to `false`.
+   *
+   * @see relocationPrefix
    */
   @get:Input
-  @get:Option(option = "enable-relocation", description = "Enable relocation of packages in the jar")
+  @get:Option(option = "enable-relocation", description = "Enable auto relocation of packages in the dependencies")
   public open val enableRelocation: Property<Boolean> = objectFactory.property(false)
 
   /**
-   * Prefix to use for relocated packages.
+   * Prefix used for auto relocation of packages in the dependencies.
    *
    * Defaults to `shadow`.
+   *
+   * @see enableRelocation
    */
   @get:Input
-  @get:Option(option = "relocation-prefix", description = "Prefix to use for relocated packages")
+  @get:Option(option = "relocation-prefix", description = "Prefix used for auto relocation of packages in the dependencies")
   public open val relocationPrefix: Property<String> = objectFactory.property(ShadowBasePlugin.SHADOW)
 
   @Internal

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -143,14 +143,14 @@ public abstract class ShadowJar :
    */
   @get:Input
   @get:Option(option = "enable-relocation", description = "Enable auto relocation of packages in the dependencies")
-  public open val enableRelocation: Property<Boolean> = objectFactory.property(false)
+  public open val enableAutoRelocation: Property<Boolean> = objectFactory.property(false)
 
   /**
    * Prefix used for auto relocation of packages in the dependencies.
    *
    * Defaults to `shadow`.
    *
-   * @see enableRelocation
+   * @see enableAutoRelocation
    */
   @get:Input
   @get:Option(option = "relocation-prefix", description = "Prefix used for auto relocation of packages in the dependencies")
@@ -384,7 +384,7 @@ public abstract class ShadowJar :
 
   private val packageRelocators: List<SimpleRelocator>
     get() {
-      if (!enableRelocation.get()) return emptyList()
+      if (!enableAutoRelocation.get()) return emptyList()
       val prefix = relocationPrefix.get()
       return includedDependencies.files.flatMap { file ->
         JarFile(file).use { jarFile ->

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -72,7 +72,7 @@ public abstract class ShadowJar :
    * Defaults to `false`.
    */
   @get:Input
-  @get:Option(option = "minimize-jar", description = "Minimizes the jar by removing unused classes")
+  @get:Option(option = "minimize-jar", description = "Minimizes the jar by removing unused classes.")
   public open val minimizeJar: Property<Boolean> = objectFactory.property(false)
 
   @get:Classpath
@@ -142,7 +142,7 @@ public abstract class ShadowJar :
    * @see relocationPrefix
    */
   @get:Input
-  @get:Option(option = "enable-auto-relocation", description = "Enables auto relocation of packages in the dependencies")
+  @get:Option(option = "enable-auto-relocation", description = "Enables auto relocation of packages in the dependencies.")
   public open val enableAutoRelocation: Property<Boolean> = objectFactory.property(false)
 
   /**
@@ -153,7 +153,7 @@ public abstract class ShadowJar :
    * @see enableAutoRelocation
    */
   @get:Input
-  @get:Option(option = "relocation-prefix", description = "Prefix used for auto relocation of packages in the dependencies")
+  @get:Option(option = "relocation-prefix", description = "Prefix used for auto relocation of packages in the dependencies.")
   public open val relocationPrefix: Property<String> = objectFactory.property(ShadowBasePlugin.SHADOW)
 
   @Internal

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -67,12 +67,12 @@ public abstract class ShadowJar :
   }
 
   /**
-   * Minimize the jar by removing unused classes.
+   * Minimizes the jar by removing unused classes.
    *
    * Defaults to `false`.
    */
   @get:Input
-  @get:Option(option = "minimize-jar", description = "Minimize the jar by removing unused classes")
+  @get:Option(option = "minimize-jar", description = "Minimizes the jar by removing unused classes")
   public open val minimizeJar: Property<Boolean> = objectFactory.property(false)
 
   @get:Classpath
@@ -135,14 +135,14 @@ public abstract class ShadowJar :
   }
 
   /**
-   * Enable auto relocation of packages in the dependencies.
+   * Enables auto relocation of packages in the dependencies.
    *
    * Defaults to `false`.
    *
    * @see relocationPrefix
    */
   @get:Input
-  @get:Option(option = "enable-relocation", description = "Enable auto relocation of packages in the dependencies")
+  @get:Option(option = "enable-auto-relocation", description = "Enables auto relocation of packages in the dependencies")
   public open val enableAutoRelocation: Property<Boolean> = objectFactory.property(false)
 
   /**


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
