### PR TITLE
Use `BufferedOutputStream` when writing the Zip file to improve performance

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 **Changed**
 
-- Use BufferedOutputStream when writing the Zip file to improve performance. ([#1579](https://github.com/GradleUp/shadow/pull/1579))
+- Use `BufferedOutputStream` when writing the Zip file to improve performance. ([#1579](https://github.com/GradleUp/shadow/pull/1579))
 
 ## [v8.3.8] (2025-07-01)
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+**Changed**
+
+- Use BufferedOutputStream when writing the Zip file to improve performance. ([#1579](https://github.com/GradleUp/shadow/pull/1579))
 
 ## [v8.3.8] (2025-07-01)
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
@@ -31,8 +31,8 @@ class DefaultZipCompressor implements ZipCompressor {
     ZipOutputStream createArchiveOutputStream(File destination) {
         try {
             ZipOutputStream zipOutputStream = entryCompressionMethod == ZipOutputStream.STORED ?
-                // It is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.
                 new ZipOutputStream(destination) :
+                // It is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.
                 new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(destination)))
             zipOutputStream.setUseZip64(zip64Mode)
             zipOutputStream.setMethod(entryCompressionMethod)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
@@ -30,7 +30,7 @@ class DefaultZipCompressor implements ZipCompressor {
     @Override
     ZipOutputStream createArchiveOutputStream(File destination) {
         try {
-            ZipOutputStream zipOutputStream = new ZipOutputStream(destination)
+            ZipOutputStream zipOutputStream = entryCompressionMethod == java.util.zip.ZipOutputStream.STORED ? new ZipOutputStream(destination) : new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(destination)))
             zipOutputStream.setUseZip64(zip64Mode)
             zipOutputStream.setMethod(entryCompressionMethod)
             return zipOutputStream

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultZipCompressor.groovy
@@ -30,7 +30,10 @@ class DefaultZipCompressor implements ZipCompressor {
     @Override
     ZipOutputStream createArchiveOutputStream(File destination) {
         try {
-            ZipOutputStream zipOutputStream = entryCompressionMethod == java.util.zip.ZipOutputStream.STORED ? new ZipOutputStream(destination) : new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(destination)))
+            ZipOutputStream zipOutputStream = entryCompressionMethod == ZipOutputStream.STORED ?
+                // It is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.
+                new ZipOutputStream(destination) :
+                new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(destination)))
             zipOutputStream.setUseZip64(zip64Mode)
             zipOutputStream.setMethod(entryCompressionMethod)
             return zipOutputStream


### PR DESCRIPTION
When not using STORED entries use a BufferedOutputStream to avoid lots of small writes to the file system.

Testing this with a 300mb jar build I see the total build time going from 40s to 30s.

Note that it is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
