### PR TITLE
Use `BufferedOutputStream` when writing the Zip file to improve performance

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -107,6 +107,7 @@
 - Expose `AbstractDependencyFilter` from `internal` to `public`. ([#1538](https://github.com/GradleUp/shadow/pull/1538))  
   You can access it via `com.github.jengelman.gradle.plugins.shadow.tasks.DependencyFilter.AbstractDependencyFilter`.
 - Mark `Action` parameters as non-null. ([#1555](https://github.com/GradleUp/shadow/pull/1555))
+- Use `BufferedOutputStream` when writing the Zip file to improve performance. ([#1580](https://github.com/GradleUp/shadow/pull/1580))
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -22,7 +22,9 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoun
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer.Companion.create
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+import java.io.BufferedOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.util.jar.JarFile
 import javax.inject.Inject
@@ -371,7 +373,12 @@ public abstract class ShadowJar : Jar() {
           ZipEntryCompression.STORED -> ZipOutputStream.STORED
           else -> throw IllegalArgumentException("Unknown Compression type $entryCompression.")
         }
-        ZipOutputStream(destination).apply {
+        val stream = if (entryCompressionMethod == ZipOutputStream.STORED) {
+          ZipOutputStream(destination)
+        } else {
+          ZipOutputStream(BufferedOutputStream(FileOutputStream(destination)))
+        }
+        stream.apply {
           setUseZip64(if (isZip64) Zip64Mode.AsNeeded else Zip64Mode.Never)
           setMethod(entryCompressionMethod)
         }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -376,7 +376,9 @@ public abstract class ShadowJar : Jar() {
         val stream = if (entryCompressionMethod == ZipOutputStream.STORED) {
           ZipOutputStream(destination)
         } else {
-          ZipOutputStream(BufferedOutputStream(FileOutputStream(destination)))
+          // Improve performance by avoiding lots of small writes to the file system.
+          // It is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.
+          ZipOutputStream(destination.outputStream().buffered())
         }
         stream.apply {
           setUseZip64(if (isZip64) Zip64Mode.AsNeeded else Zip64Mode.Never)


### PR DESCRIPTION
When not using STORED entries use a BufferedOutputStream to avoid lots of small writes to the file system.

Testing this with a 300mb jar build I see the total build time going from 40s to 30s.

Note that it is not possible to do this with STORED entries as the implementation requires a RandomAccessFile to update the CRC after write.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
