### PR TITLE
Fix excluding dependencies whose versions contain `+`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -15,6 +15,10 @@
   The Gradle Module descriptors (`org.codehaus.groovy.runtime.ExtensionModule` files) defined under `META-INF/services/`
   and `META-INF/groovy` will be merged into `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule`.
 
+### Fixed
+
+- Fix excluding dependencies whose versions contain `+`. ([#1597](https://github.com/GradleUp/shadow/pull/1597))
+
 ## [9.1.0](https://github.com/GradleUp/shadow/compare/9.1.0) - 2025-08-29
 
 ### Added

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FilteringTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FilteringTest.kt
@@ -1,6 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import assertk.assertThat
+import com.github.jengelman.gradle.plugins.shadow.util.Issue
 import com.github.jengelman.gradle.plugins.shadow.util.containsOnly
 import kotlin.io.path.appendText
 import kotlin.io.path.writeText
@@ -161,6 +162,32 @@ class FilteringTest : BasePluginTest() {
         }
       """.trimIndent(),
     )
+
+    run(serverShadowJarPath)
+
+    assertThat(outputServerShadowedJar).useAll {
+      containsOnly(
+        "server/",
+        "server/Server.class",
+        *junitEntries,
+        *manifestEntries,
+      )
+    }
+  }
+
+  @Issue(
+    "https://github.com/GradleUp/shadow/issues/671",
+  )
+  @Test
+  fun filterProjectThatVersionContainsPlus() {
+    writeClientAndServerModules(
+      serverShadowBlock = """
+        dependencies {
+          exclude(project(':client'))
+        }
+      """.trimIndent(),
+    )
+    path("client/build.gradle").appendText("version = '1.0.0+1'")
 
     run(serverShadowJarPath)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -109,9 +109,19 @@ public interface DependencyFilter : Serializable {
 
     private fun Dependency.toSpec(): Spec<ResolvedDependency> {
       return Spec<ResolvedDependency> { resolvedDependency ->
-        (group == null || resolvedDependency.moduleGroup.matches(group!!.toRegex())) &&
-          resolvedDependency.moduleName.matches(name.toRegex()) &&
-          (version == null || resolvedDependency.moduleVersion.matches(version!!.toRegex()))
+        val groupMatch = group?.let {
+          it == resolvedDependency.moduleGroup || resolvedDependency.moduleGroup.matches(it.toRegex())
+        } ?: true
+        val nameMatch = name.let {
+          it == resolvedDependency.moduleName || resolvedDependency.moduleName.matches(it.toRegex())
+        }
+        val versionMatch = version?.let {
+          // Version like `1.0.0+1` can't be converted to regex directly because `+` is a special character in regex.
+          // So we check for exact match first, then fallback to regex match.
+          it == resolvedDependency.moduleVersion || resolvedDependency.moduleVersion.matches(it.toRegex())
+        } ?: true
+
+        groupMatch && nameMatch && versionMatch
       }
     }
   }


### PR DESCRIPTION
Closes #671.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
