### PR TITLE
Fix the regression of resolving circular dependencies in `MinimizeDependencyFilter`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fix the regression of can't shadow directory inputs. ([#1606](https://github.com/GradleUp/shadow/pull/1606))
+- Fix the regression of `MinimizeDependencyFilter`. ([#1611](https://github.com/GradleUp/shadow/pull/1611))
 
 ## [9.0.0](https://github.com/GradleUp/shadow/compare/9.0.0) - 2025-08-07
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -13,7 +13,6 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-import assertk.assertions.isRegularFile
 import assertk.assertions.isTrue
 import assertk.assertions.single
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin.Companion.ENABLE_DEVELOCITY_INTEGRATION_PROPERTY
@@ -969,33 +968,6 @@ class JavaPluginsTest : BasePluginTest() {
       "Duplicate entries found in the shadowed JAR:",
       "a.properties (2 times)",
     )
-  }
-
-  @Test
-  fun reproduceIssue1610() {
-    projectScript.appendText(
-      """
-        $shadowJarTask {
-          dependencies { exclude(dependency("org.slf4j:slf4j-api")) }
-
-          exclude("META-INF/maven/**/*")
-
-          minimize { }
-
-          relocate("com.foo", "shadow.com.foo")
-
-          mergeServiceFiles()
-        }
-      """.trimIndent(),
-    )
-
-    run(shadowJarTask)
-
-    assertThat(outputShadowedJar).useAll {
-      containsAtLeast(
-        *manifestEntries,
-      )
-    }
   }
 
   private fun dependencies(configuration: String, vararg flags: String): String {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -13,6 +13,7 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isRegularFile
 import assertk.assertions.isTrue
 import assertk.assertions.single
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin.Companion.ENABLE_DEVELOCITY_INTEGRATION_PROPERTY
@@ -968,6 +969,33 @@ class JavaPluginsTest : BasePluginTest() {
       "Duplicate entries found in the shadowed JAR:",
       "a.properties (2 times)",
     )
+  }
+
+  @Test
+  fun reproduceIssue1610() {
+    projectScript.appendText(
+      """
+        $shadowJarTask {
+          dependencies { exclude(dependency("org.slf4j:slf4j-api")) }
+
+          exclude("META-INF/maven/**/*")
+
+          minimize { }
+
+          relocate("com.foo", "shadow.com.foo")
+
+          mergeServiceFiles()
+        }
+      """.trimIndent(),
+    )
+
+    run(shadowJarTask)
+
+    assertThat(outputShadowedJar).useAll {
+      containsAtLeast(
+        *manifestEntries,
+      )
+    }
   }
 
   private fun dependencies(configuration: String, vararg flags: String): String {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -5,10 +5,8 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.SHAD
 import com.github.jengelman.gradle.plugins.shadow.util.containsAtLeast
 import com.github.jengelman.gradle.plugins.shadow.util.containsNone
 import com.github.jengelman.gradle.plugins.shadow.util.containsOnly
-import kotlin.io.appendText
 import kotlin.io.path.appendText
 import kotlin.io.path.writeText
-import kotlin.io.writeText
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -211,49 +209,6 @@ class MinimizeTest : BasePluginTest() {
         "client/Client.class",
         "server/Server.class",
         *junitEntries,
-      )
-    }
-  }
-
-  /**
-   * 'impl' depends on 'api', which depends on 'lib'.
-   * 'api' is excluded from minimization.
-   * 'lib' should also be excluded as it's a transitive dependency of an excluded project.
-   */
-  @Test
-  fun excludeTransitiveDependencyOfExcludedProject() {
-    writeApiLibAndImplModules()
-    path("api/build.gradle").writeText(
-      """
-        plugins {
-          id 'java-library'
-        }
-        dependencies {
-          api project(':lib')
-        }
-      """.trimIndent(),
-    )
-    path("impl/build.gradle").appendText(
-      """
-        $shadowJarTask {
-          minimize {
-            exclude(project(':api'))
-          }
-        }
-      """.trimIndent(),
-    )
-
-    run(":impl:$SHADOW_JAR_TASK_NAME")
-
-    assertThat(jarPath("impl/build/libs/impl-all.jar")).useAll {
-      containsAtLeast(
-        "impl/",
-        "impl/SimpleEntity.class",
-        *manifestEntries,
-      )
-      containsNone(
-        "api/",
-        "lib/",
       )
     }
   }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -5,8 +5,10 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.SHAD
 import com.github.jengelman.gradle.plugins.shadow.util.containsAtLeast
 import com.github.jengelman.gradle.plugins.shadow.util.containsNone
 import com.github.jengelman.gradle.plugins.shadow.util.containsOnly
+import kotlin.io.appendText
 import kotlin.io.path.appendText
 import kotlin.io.path.writeText
+import kotlin.io.writeText
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -209,6 +211,49 @@ class MinimizeTest : BasePluginTest() {
         "client/Client.class",
         "server/Server.class",
         *junitEntries,
+      )
+    }
+  }
+
+  /**
+   * 'impl' depends on 'api', which depends on 'lib'.
+   * 'api' is excluded from minimization.
+   * 'lib' should also be excluded as it's a transitive dependency of an excluded project.
+   */
+  @Test
+  fun excludeTransitiveDependencyOfExcludedProject() {
+    writeApiLibAndImplModules()
+    path("api/build.gradle").writeText(
+      """
+        plugins {
+          id 'java-library'
+        }
+        dependencies {
+          api project(':lib')
+        }
+      """.trimIndent(),
+    )
+    path("impl/build.gradle").appendText(
+      """
+        $shadowJarTask {
+          minimize {
+            exclude(project(':api'))
+          }
+        }
+      """.trimIndent(),
+    )
+
+    run(":impl:$SHADOW_JAR_TASK_NAME")
+
+    assertThat(jarPath("impl/build/libs/impl-all.jar")).useAll {
+      containsAtLeast(
+        "impl/",
+        "impl/SimpleEntity.class",
+        *manifestEntries,
+      )
+      containsNone(
+        "api/",
+        "lib/",
       )
     }
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeDependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeDependencyFilter.kt
@@ -13,12 +13,14 @@ internal class MinimizeDependencyFilter(
     excludedDependencies: MutableSet<ResolvedDependency>,
   ) {
     dependencies.forEach {
-      if (it.isIncluded() && !isParentExcluded(excludedDependencies, it)) {
+      val added = if (it.isIncluded() && !isParentExcluded(excludedDependencies, it)) {
         includedDependencies.add(it)
       } else {
         excludedDependencies.add(it)
       }
-      resolve(it.children, includedDependencies, excludedDependencies)
+      if (added) {
+        resolve(it.children, includedDependencies, excludedDependencies)
+      }
     }
   }
 


### PR DESCRIPTION
- Closes #1610.
- Fixes https://github.com/GradleUp/shadow/pull/1021#discussion_r2262468388.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
