### PR TITLE
Default `duplicatesStrategy` back to `EXCLUDE`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -6,6 +6,10 @@
 ### Changed
 
 - Improve the error message for empty `mainClassName`. ([#1601](https://github.com/GradleUp/shadow/pull/1601))
+- Default `duplicatesStrategy` back to `EXCLUDE`. ([#1617](https://github.com/GradleUp/shadow/pull/1617))
+    - This strategy behaviors with 8.x series, which is more compatible for most upgrading.
+    - For most `ResourceTransformer` users, you need to override the strategy to `INCLUDE` to make them work.
+    - See more details about the strategies at [Handling Duplicates Strategy](https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy).
 
 ### Fixed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,7 +7,7 @@
 
 - Improve the error message for empty `mainClassName`. ([#1601](https://github.com/GradleUp/shadow/pull/1601))
 - Default `duplicatesStrategy` back to `EXCLUDE`. ([#1617](https://github.com/GradleUp/shadow/pull/1617))
-    - This strategy behaviors with 8.x series, which is more compatible for most upgrading.
+    - This strategy is consistent with 8.x series behavior, which is more compatible for most users upgrading.
     - For most `ResourceTransformer` users, you need to override the strategy to `INCLUDE` to make them work.
     - See more details about the strategies at [Handling Duplicates Strategy](https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy).
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -825,7 +825,6 @@ class JavaPluginsTest : BasePluginTest() {
           ${implementationFiles(fooJar)}
         }
         $shadowJarTask {
-          duplicatesStrategy = DuplicatesStrategy.EXCLUDE
           excludes.remove(
             'module-info.class'
           )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -929,6 +929,7 @@ class JavaPluginsTest : BasePluginTest() {
           ${implementationFiles(artifactAJar)}
         }
         $shadowJarTask {
+          duplicatesStrategy = DuplicatesStrategy.INCLUDE
           failOnDuplicateEntries = $enable
         }
       """.trimIndent(),
@@ -954,6 +955,9 @@ class JavaPluginsTest : BasePluginTest() {
       """
         dependencies {
           ${implementationFiles(artifactAJar)}
+        }
+        $shadowJarTask {
+          duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }
       """.trimIndent(),
     )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -71,7 +71,7 @@ class JavaPluginsTest : BasePluginTest() {
 
     // Check extended properties.
     with(shadowTask as Jar) {
-      assertThat(duplicatesStrategy).isEqualTo(DuplicatesStrategy.INCLUDE)
+      assertThat(duplicatesStrategy).isEqualTo(DuplicatesStrategy.EXCLUDE)
       assertThat(archiveAppendix.orNull).isNull()
       assertThat(archiveBaseName.get()).isEqualTo(projectName)
       assertThat(archiveClassifier.get()).isEqualTo("all")

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
@@ -3,8 +3,23 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.BasePluginTest
 import com.github.jengelman.gradle.plugins.shadow.util.JarBuilder
 import java.nio.file.Path
+import kotlin.io.path.appendText
+import org.junit.jupiter.api.BeforeEach
 
 abstract class BaseTransformerTest : BasePluginTest() {
+  @BeforeEach
+  override fun setup() {
+    super.setup()
+    projectScript.appendText(
+      """
+        $shadowJarTask {
+          // Most transformers in tests require this to handle duplicate resources.
+          duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+      """.trimIndent() + lineSeparator,
+    )
+  }
+
   fun buildJarOne(
     builder: JarBuilder.() -> Unit = {
       insert(ENTRY_SERVICES_SHADE, CONTENT_ONE)

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -230,6 +230,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     projectScript.appendText(
       """
         $shadowJarTask {
+          duplicatesStrategy = DuplicatesStrategy.EXCLUDE
           filesMatching('$ENTRY_SERVICES_SHADE') {
             duplicatesStrategy = DuplicatesStrategy.INCLUDE
           }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -176,6 +176,7 @@ public abstract class ShadowJar : Jar() {
    * This is related to setting [getDuplicatesStrategy] to [FAIL] but there are some differences:
    * - It only checks the entries in the shadowed jar, not the input files.
    * - It works with setting [getDuplicatesStrategy] to any value.
+   * - Usually used with setting [getDuplicatesStrategy] to [INCLUDE] or [WARN].
    * - It provides a stricter check before the JAR is created.
    *
    * Defaults to `false`.
@@ -198,24 +199,26 @@ public abstract class ShadowJar : Jar() {
    *
    * This global strategy can be overridden for individual files by using [filesMatching].
    *
-   * The default value is [INCLUDE]. Different strategies will lead to different results for `foo/bar` files in the JARs to be merged:
+   * The default value is [EXCLUDE]. Different strategies will lead to different results for `foo/bar` files in the JARs to be merged:
    *
    * - [EXCLUDE]: The **first** `foo/bar` file will be included in the final JAR.
    * - [FAIL]: **Fail** the build with a `DuplicateFileCopyingException` if there are duplicate `foo/bar` files.
-   * - [INCLUDE]: Duplicate `foo/bar` entries will be included in the final JAR.
+   * - [INCLUDE]: **Duplicate** `foo/bar` entries will be included in the final JAR.
    * - [INHERIT]: **Fail** the build with an exception like `Entry .* is a duplicate but no duplicate handling strategy has been set`.
    * - [WARN]: **Warn** about duplicates in the build log, this behaves exactly as [INHERIT] otherwise.
    *
    * **NOTE:** The strategy takes precedence over transforming and relocating.
-   * Some [ResourceTransformer]s like [ServiceFileTransformer] will not work as expected with setting the strategy to
-   * [EXCLUDE], as the service files are excluded beforehand. Want [ResourceTransformer]s and the strategy to work
-   * together? There are several ways to do it:
+   * Some [ResourceTransformer]s like [ServiceFileTransformer] will not work as expected with setting the strategy to [EXCLUDE],
+   * as the duplicate resource files fed for them are excluded beforehand.
+   * Want [ResourceTransformer]s and the strategy to work together? There are several steps to take:
    *
-   * - Use [filesMatching] to override the strategy for specific files.
-   * - Keep `duplicatesStrategy = INCLUDE` and write your own [ResourceTransformer] to handle duplicates.
-   *
-   * If you just want to keep the current behavior and preserve the first found resources, there is a simple built-in one
-   * called [PreserveFirstFoundResourceTransformer].
+   * 1. Set the strategy to [INCLUDE] or [WARN].
+   * 2. Apply your [ResourceTransformer]s.
+   * 3. Remove duplicate entries by
+   *     - overriding the default strategy for specific files using [filesMatching]
+   *     - applying [PreserveFirstFoundResourceTransformer]
+   *     - or something similar.
+   * 4. Optionally, enable [failOnDuplicateEntries] to check duplicate entries in the final JAR.
    *
    * @see [filesMatching]
    * @see [DuplicatesStrategy]

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -71,7 +71,7 @@ public abstract class ShadowJar : Jar() {
     description = "Create a combined JAR of project and runtime dependencies"
 
     // https://github.com/gradle/gradle/blob/df5bc230c57db70aa3f6909403e5f89d7efde531/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/DuplicateHandlingCopyActionDecorator.java#L55-L64
-    duplicatesStrategy = INCLUDE
+    duplicatesStrategy = EXCLUDE
     manifest = DefaultInheritManifest(services.get(FileResolver::class.java))
 
     outputs.doNotCacheIf("Has one or more transforms or relocators that are not cacheable") {


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
