### PR TITLE
fix: missing space between default preamble1 and projectName in Apach…

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -43,7 +43,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
       // ------------------------------------------------------------------
       // NOTICE file corresponding to the section 4d of The Apache License,
       // Version 2.0, in this case for
-    """.trimIndent(),
+    """.trimIndent() + " ",
   )
 
   @get:Input


### PR DESCRIPTION
In the `ApacheNoticeResourceTransformer`, the maven-shade-plugin includes [a space at the end of the default header](https://github.com/apache/maven-shade-plugin/blob/d008516be065367578601b7c791dc4bfc9ef90a9/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java#L54). Shadow's implementation is missing the space, resulting in a header that looks like this:
```
// ------------------------------------------------------------------
// NOTICE file corresponding to the section 4d of The Apache License,
// Version 2.0, in this case forMyProject
// ------------------------------------------------------------------
```

---

- [] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
