### PR TITLE
Fix using `ApacheNoticeResourceTransformer` without `projectName`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Fix missing space in `ApacheNoticeResourceTransformer` preamble causing malformed NOTICE header. ([#1623](https://github.com/GradleUp/shadow/pull/1623)).
+- Fix using `ApacheNoticeResourceTransformer` without `projectName`. ([#1627](https://github.com/GradleUp/shadow/pull/1627)).
 
 ## [9.0.1](https://github.com/GradleUp/shadow/releases/tag/9.0.1) - 2025-08-09
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -214,17 +214,13 @@ class TransformersTest : BaseTransformerTest() {
   @Test
   fun apacheNoticeTransformerWithRealDependencies() {
     projectScript.appendText(
-      """
-        dependencies {
+      transform<ApacheNoticeResourceTransformer>(
+        dependenciesBlock = """
           implementation 'org.apache.commons:commons-dbcp2:2.13.0'
           implementation 'org.apache.commons:commons-pool2:2.12.0'
-        }
-        $shadowJarTask {
-          transform(${ApacheNoticeResourceTransformer::class.java.name}) {
-            addHeader = false
-          }
-        }
-      """.trimIndent(),
+        """.trimIndent(),
+        transformerBlock = "addHeader = false",
+      ),
     )
 
     run(shadowJarPath) // This will fail

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -211,6 +211,25 @@ class TransformersTest : BaseTransformerTest() {
     }
   }
 
+  @Test
+  fun apacheNoticeTransformerWithRealDependencies() {
+    projectScript.appendText(
+      """
+        dependencies {
+          implementation 'org.apache.commons:commons-dbcp2:2.13.0'
+          implementation 'org.apache.commons:commons-pool2:2.12.0'
+        }
+        $shadowJarTask {
+          transform(${ApacheNoticeResourceTransformer::class.java.name}) {
+            addHeader = false
+          }
+        }
+      """.trimIndent(),
+    )
+
+    run(shadowJarPath) // This will fail
+  }
+
   @ParameterizedTest
   @MethodSource("transformerConfigProvider")
   fun otherTransformers(pair: Pair<String, KClass<*>>) {
@@ -268,7 +287,6 @@ class TransformersTest : BaseTransformerTest() {
     @JvmStatic
     fun transformerConfigProvider() = listOf(
       "" to ApacheLicenseResourceTransformer::class,
-      "" to ApacheNoticeResourceTransformer::class,
       "" to ComponentsXmlResourceTransformer::class,
       "" to ManifestAppenderTransformer::class,
       "" to ManifestResourceTransformer::class,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -31,6 +31,11 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
   private val organizationEntries = mutableMapOf<String, MutableSet<String>>()
   private inline val charset get() = Charset.forName(charsetName.get())
 
+  /**
+   * Fallback [copyright] as the [Property] value can't be changed in execution phase.
+   */
+  private var fallbackCopyright: String? = null
+
   @get:Input
   public open val projectName: Property<String> = objectFactory.property("")
 
@@ -129,7 +134,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
         } else {
           val entry = sb.toString()
           if (entry.startsWith(projectName) && entry.contains("Copyright ")) {
-            copyright.set(entry)
+            fallbackCopyright = entry
           }
           if (currentOrg == null) {
             entries.add(entry)
@@ -156,7 +161,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
   override fun hasTransformedResource(): Boolean = true
 
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
-    val copyright = copyright.orNull
+    val copyright = copyright.orNull ?: fallbackCopyright
 
     os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
 


### PR DESCRIPTION
Closes #1626.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
