### PR TITLE
Fix extra indents of `ApacheNoticeResourceTransformer` output

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,6 +7,7 @@
 
 - Fix missing space in `ApacheNoticeResourceTransformer` preamble causing malformed NOTICE header. ([#1623](https://github.com/GradleUp/shadow/pull/1623)).
 - Fix using `ApacheNoticeResourceTransformer` without `projectName`. ([#1627](https://github.com/GradleUp/shadow/pull/1627)).
+- Fix extra indents of `ApacheNoticeResourceTransformer` output. ([#1628](https://github.com/GradleUp/shadow/pull/1628)).
 
 ## [9.0.1](https://github.com/GradleUp/shadow/releases/tag/9.0.1) - 2025-08-09
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -255,7 +255,7 @@ class TransformersTest : BaseTransformerTest() {
         noticeEntry,
         *manifestEntries,
       )
-      getContent(noticeEntry).transform { it.trim() }.isEqualTo(
+      getContent(noticeEntry).isEqualTo(
         """
         Apache Commons Pool
         Copyright 2001-2025 The Apache Software Foundation

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -163,35 +163,35 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     val copyright = copyright.orNull ?: fallbackCopyright
 
-    os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
-
-    val writer = PrintWriter(os.writer(charset))
-
-    var count = 0
-    for (line in entries) {
-      count++
-      if (line == copyright && count != 2) continue
-      if (count == 2 && copyright != null) {
-        writer.print(copyright)
-        writer.print('\n')
-      } else {
-        writer.print(line)
-        writer.print('\n')
-      }
-      if (count == 3) {
-        // Do org stuff.
-        for ((key, value) in organizationEntries) {
-          writer.print(key)
-          writer.print('\n')
-          for (l in value) {
-            writer.print(l)
+    val notice = buildString {
+      var count = 0
+      for (line in entries) {
+        count++
+        if (line == copyright && count != 2) continue
+        if (count == 2 && copyright != null) {
+          append(copyright)
+          append('\n')
+        } else {
+          append(line)
+          append('\n')
+        }
+        if (count == 3) {
+          // Do org stuff.
+          for ((key, value) in organizationEntries) {
+            append(key)
+            append('\n')
+            for (l in value) {
+              append(l)
+            }
+            append('\n')
           }
-          writer.print('\n')
         }
       }
     }
 
-    writer.flush()
+    os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
+    os.write(notice.toByteArray(charset))
+
     entries.clear()
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -2,7 +2,6 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.zipEntry
-import java.io.PrintWriter
 import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -162,35 +161,33 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
 
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     val copyright = copyright.orNull ?: fallbackCopyright
-
-    val notice = buildString {
-      var count = 0
-      for (line in entries) {
-        count++
-        if (line == copyright && count != 2) continue
-        if (count == 2 && copyright != null) {
-          append(copyright)
-          append('\n')
-        } else {
-          append(line)
-          append('\n')
-        }
-        if (count == 3) {
-          // Do org stuff.
-          for ((key, value) in organizationEntries) {
-            append(key)
-            append('\n')
-            for (l in value) {
-              append(l)
-            }
-            append('\n')
+    val sb = StringBuilder()
+    var count = 0
+    for (line in entries) {
+      count++
+      if (line == copyright && count != 2) continue
+      if (count == 2 && copyright != null) {
+        sb.append(copyright)
+        sb.append('\n')
+      } else {
+        sb.append(line)
+        sb.append('\n')
+      }
+      if (count == 3) {
+        // Do org stuff.
+        for ((key, value) in organizationEntries) {
+          sb.append(key)
+          sb.append('\n')
+          for (l in value) {
+            sb.append(l)
           }
+          sb.append('\n')
         }
       }
     }
 
     os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
-    os.write(notice.trim().toByteArray(charset))
+    os.write(sb.toString().trim().toByteArray(charset))
 
     entries.clear()
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -188,6 +188,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
 
     os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
     os.write(sb.toString().trim().toByteArray(charset))
+    os.closeEntry()
 
     entries.clear()
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -190,7 +190,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
     }
 
     os.putNextEntry(zipEntry(NOTICE_PATH, preserveFileTimestamps))
-    os.write(notice.toByteArray(charset))
+    os.write(notice.trim().toByteArray(charset))
 
     entries.clear()
   }


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
