### PR TITLE
Use `StringBuilder` for `ApacheNoticeResourceTransformer.transform`

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -107,7 +107,7 @@ public open class ApacheNoticeResourceTransformer @Inject constructor(
 
     val reader = context.inputStream.bufferedReader(charset)
     var line = reader.readLine()
-    val sb = StringBuffer()
+    val sb = StringBuilder()
     var currentOrg: MutableSet<String>? = null
     var lineCount = 0
     while (line != null) {


### PR DESCRIPTION
We don't need thread-safety for this function.
