### PR TITLE
Fix resolving BOM dependencies when `minimize` is enabled

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 **Fixed**
 
-- Fix resolving BOM dependencies when enable `minimize`. ([#1638](https://github.com/GradleUp/shadow/pull/1638))
+- Fix resolving BOM dependencies when `minimize` is enabled. ([#1638](https://github.com/GradleUp/shadow/pull/1638))
 
 ## [v8.3.9] (2025-08-05)
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+**Fixed**
+
+- Fix resolving BOM dependencies when enable `minimize`. ([#1638](https://github.com/GradleUp/shadow/pull/1638))
 
 ## [v8.3.9] (2025-08-05)
 

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/UnusedTracker.groovy
@@ -77,7 +77,10 @@ class UnusedTracker {
                 apiJars.addAll(dep.files)
             } else {
                 addJar(runtimeConfiguration, dep, apiJars)
-                apiJars.add(runtimeConfiguration.find { it.name.startsWith("${dep.name}-") } as File)
+                def jarFile = runtimeConfiguration.find { it.name.startsWith("${dep.name}-") }
+                if (jarFile != null) {
+                    apiJars.add(jarFile)
+                }
             }
         }
 


### PR DESCRIPTION
Ports #1637.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
