### PR TITLE
Run build tasks with stacktrace on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew build "-PtestGradleVersion=${{ matrix.gradle }}"
+      - run: ./gradlew build "-PtestGradleVersion=${{ matrix.gradle }}" --stacktrace
 
   # Status check that is required in branch protection rules.
   build-status:


### PR DESCRIPTION
Easier to capture more details about

```
* What went wrong:
Execution failed for task ':lintReportJvm'.
> A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintTask$AndroidLintLauncherWorkAction
   > There was a failure while executing work items
      > A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
```

on CI.

