### PR TITLE
Remove override of `maxParallelForks`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,8 +182,6 @@ testing.suites {
     targets.configureEach {
       testTask {
         systemProperty("TEST_GRADLE_VERSION", testGradleVersion)
-        maxParallelForks = 1
-
         develocity {
           testRetry {
             maxRetries = 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,7 @@ testing.suites {
     targets.configureEach {
       testTask {
         systemProperty("TEST_GRADLE_VERSION", testGradleVersion)
-        maxParallelForks = Runtime.getRuntime().availableProcessors()
+        maxParallelForks = 1
 
         develocity {
           testRetry {


### PR DESCRIPTION
This doesn’t seem to help much with speeding things up...