### PR TITLE
Allow opting out of `TARGET_JVM_VERSION_ATTRIBUTE`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -36,6 +36,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin$C
 
 public abstract interface class com/github/jengelman/gradle/plugins/shadow/ShadowExtension {
 	public abstract fun getAddShadowVariantIntoJavaComponent ()Lorg/gradle/api/provider/Property;
+	public abstract fun getAddTargetJvmVersionAttribute ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin : org/gradle/api/Plugin {

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,9 +3,10 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.0.2...HEAD) - 2025-xx-xx
 
-## Changed
+## Added
 
 - Allow opting out of `shadowRuntimeElements` variant. ([#1662](https://github.com/GradleUp/shadow/pull/1662))
+- Allow opting out of `TARGET_JVM_VERSION_ATTRIBUTE`. ([#1674](https://github.com/GradleUp/shadow/pull/1674))
 
 ## Changed
 

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -109,7 +109,7 @@ the `shadow` extension to `false`. If you want to publish the standard JAR only,
 
 The target JVM version attribute (`org.gradle.jvm.version`) of the shadowed variant is added by default, it is useful
 for consumers to select the correct variant based on their target JVM version. But it may cause issues in some cases,
-you can disable this by setting the `addJvmVersionAttribute` property in the `shadow` extension to `false`:
+you can disable this by setting the `addTargetJvmVersionAttribute` property in the `shadow` extension to `false`:
 
 === "Kotlin"
 

--- a/docs/publishing/README.md
+++ b/docs/publishing/README.md
@@ -107,6 +107,26 @@ the `shadow` extension to `false`. If you want to publish the standard JAR only,
     }
     ```
 
+The target JVM version attribute (`org.gradle.jvm.version`) of the shadowed variant is added by default, it is useful
+for consumers to select the correct variant based on their target JVM version. But it may cause issues in some cases,
+you can disable this by setting the `addJvmVersionAttribute` property in the `shadow` extension to `false`:
+
+=== "Kotlin"
+
+    ```kotlin
+    shadow {
+      addTargetJvmVersionAttribute = false
+    }
+    ```
+
+=== "Groovy"
+
+    ```groovy
+    shadow {
+      addTargetJvmVersionAttribute = false
+    }
+    ```
+
 ## Shadow Configuration and Publishing
 
 The Shadow plugin provides a custom configuration (`configurations.shadow`) to specify

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -68,6 +68,7 @@ class JavaPluginsTest : BasePluginTest() {
 
     with(project.extensions.getByType(ShadowExtension::class.java)) {
       assertThat(addShadowVariantIntoJavaComponent.get()).isTrue()
+      assertThat(addTargetJvmVersionAttribute.get()).isTrue()
     }
 
     project.plugins.apply(JavaPlugin::class.java)

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/PublishingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/PublishingTest.kt
@@ -164,6 +164,35 @@ class PublishingTest : BasePluginTest() {
   }
 
   @Test
+  fun dontInjectTargetJvmVersionWhenOptingOut() {
+    projectScript.appendText(
+      publishConfiguration(
+        projectBlock = """
+          shadow {
+            addTargetJvmVersionAttribute = false
+          }
+        """.trimIndent(),
+        shadowBlock = """
+          archiveClassifier = ''
+          archiveBaseName = 'maven-all'
+        """.trimIndent(),
+      ),
+    )
+
+    val result = publish(infoArgument)
+
+    assertThat(result.output).contains(
+      "Skipping setting org.gradle.jvm.version attribute for shadowRuntimeElements configuration.",
+    )
+    assertShadowVariantCommon(
+      gmm = gmmAdapter.fromJson(repoPath("my/maven-all/1.0/maven-all-1.0.module")),
+      variantAttrs = shadowVariantAttrs.filterNot { (name, _) ->
+        name == TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name
+      }.toTypedArray(),
+    )
+  }
+
+  @Test
   fun publishShadowJarInsteadOfJar() {
     projectScript.appendText(
       publishConfiguration(

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin.kt
@@ -21,6 +21,7 @@ public abstract class ShadowBasePlugin : Plugin<Project> {
     }
     with(extensions.create(EXTENSION_NAME, ShadowExtension::class.java)) {
       addShadowVariantIntoJavaComponent.convention(true)
+      addTargetJvmVersionAttribute.convention(true)
     }
     @Suppress("EagerGradleConfiguration") // this should be created eagerly.
     configurations.create(CONFIGURATION_NAME)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.kt
@@ -14,7 +14,7 @@ public interface ShadowExtension {
 
   /**
    * If `true`, adds a [TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE] attribute to the Gradle Module Metadata of the
-   * shadowed JAR. This attribute indicates the target JVM version for which the shadow JAR is built.
+   * shadowed JAR. This affects how consumers resolve the published artifact based on the target JVM version.
    *
    * Defaults to `true`.
    */

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowExtension.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow
 
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.provider.Property
 
 public interface ShadowExtension {
@@ -10,4 +11,12 @@ public interface ShadowExtension {
    * Defaults to `true`.
    */
   public val addShadowVariantIntoJavaComponent: Property<Boolean>
+
+  /**
+   * If `true`, adds a [TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE] attribute to the Gradle Module Metadata of the
+   * shadowed JAR. This attribute indicates the target JVM version for which the shadow JAR is built.
+   *
+   * Defaults to `true`.
+   */
+  public val addTargetJvmVersionAttribute: Property<Boolean>
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -69,7 +69,10 @@ public abstract class ShadowJavaPlugin @Inject constructor(
 
     // Must use afterEvaluate here as we need to check the value of targetJvmVersion and track its changes.
     afterEvaluate {
-      if (!shadow.addTargetJvmVersionAttribute.get()) return@afterEvaluate
+      if (!shadow.addTargetJvmVersionAttribute.get()) {
+        logger.info("Skipping setting ${TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name} attribute for ${shadowRuntimeElements.name} configuration.")
+        return@afterEvaluate
+      }
       val targetJvmVersion = configurations.named(COMPILE_CLASSPATH_CONFIGURATION_NAME).map { compileClasspath ->
         compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
       }.getOrElse(javaPluginExtension.targetCompatibility.majorVersion.toInt())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -69,6 +69,7 @@ public abstract class ShadowJavaPlugin @Inject constructor(
 
     // Must use afterEvaluate here as we need to check the value of targetJvmVersion and track its changes.
     afterEvaluate {
+      if (!shadow.addTargetJvmVersionAttribute.get()) return@afterEvaluate
       val targetJvmVersion = configurations.named(COMPILE_CLASSPATH_CONFIGURATION_NAME).map { compileClasspath ->
         compileClasspath.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
       }.getOrElse(javaPluginExtension.targetCompatibility.majorVersion.toInt())


### PR DESCRIPTION
Closes #1540.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
