### PR TITLE
Do not write modified class files for no-op relocations

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -12,7 +12,7 @@
 ## Changed
 
 - Don't inject `TargetJvmVersion` attribute when automatic JVM targeting is disabled. ([#1666](https://github.com/GradleUp/shadow/pull/1666))
-- Keep class bytes unmodified if possible ([#1694](https://github.com/GradleUp/shadow/pull/1694))
+- Do not write modified class files for no-op relocations. ([#1694](https://github.com/GradleUp/shadow/pull/1694))
 
 
 ## [9.0.2](https://github.com/GradleUp/shadow/releases/tag/9.0.2) - 2025-08-15

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -12,6 +12,7 @@
 ## Changed
 
 - Don't inject `TargetJvmVersion` attribute when automatic JVM targeting is disabled. ([#1666](https://github.com/GradleUp/shadow/pull/1666))
+- Keep class bytes unmodified if possible ([#1694](https://github.com/GradleUp/shadow/pull/1694))
 
 
 ## [9.0.2](https://github.com/GradleUp/shadow/releases/tag/9.0.2) - 2025-08-15

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -58,6 +58,7 @@ abstract class BasePluginTest {
 
   val projectScript: Path get() = path("build.gradle")
   val settingsScript: Path get() = path("settings.gradle")
+  val outputJar: JarPath get() = jarPath("build/libs/my-1.0.jar")
   open val outputShadowedJar: JarPath get() = jarPath("build/libs/my-1.0-all.jar")
   val outputServerShadowedJar: JarPath get() = jarPath("server/build/libs/server-1.0-all.jar")
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
@@ -10,8 +10,8 @@ import assertk.fail
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction.Companion.CONSTANT_TIME_FOR_ZIP_ENTRIES
 import com.github.jengelman.gradle.plugins.shadow.util.Issue
-import com.github.jengelman.gradle.plugins.shadow.util.JarPath
 import com.github.jengelman.gradle.plugins.shadow.util.containsOnly
+import com.github.jengelman.gradle.plugins.shadow.util.getBytes
 import com.github.jengelman.gradle.plugins.shadow.util.runProcess
 import java.net.URLClassLoader
 import kotlin.io.path.appendText
@@ -542,15 +542,15 @@ class RelocationTest : BasePluginTest() {
           implementation 'junit:junit:3.8.2'
         }
         $shadowJarTask {
-          relocate('junit', 'shadow.junit')
+          enableAutoRelocation = true
         }
       """.trimIndent(),
     )
 
     run(":jar", shadowJarPath)
 
-    val originalBytes = outputJar.getEntryBytes(mainClassEntry)
-    val relocatedBytes = outputShadowedJar.getEntryBytes(mainClassEntry)
+    val originalBytes = outputJar.use { it.getBytes(mainClassEntry) }
+    val relocatedBytes = outputShadowedJar.use { it.getBytes(mainClassEntry) }
     assertThat(relocatedBytes).isEqualTo(originalBytes)
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/JarPath.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/JarPath.kt
@@ -26,6 +26,11 @@ class JarPath(val path: Path) :
     return manifest.mainAttributes.getValue(name)
   }
 
+  fun getEntryBytes(entryName: String): ByteArray = use { jar ->
+    val entry = jar.entries().asSequence().single { it.name == entryName }
+    jar.getInputStream(entry).use { it.readBytes() }
+  }
+
   override fun toString(): String = path.toString()
 }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/JarPath.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/JarPath.kt
@@ -26,12 +26,11 @@ class JarPath(val path: Path) :
     return manifest.mainAttributes.getValue(name)
   }
 
-  fun getEntryBytes(entryName: String): ByteArray = use { jar ->
-    val entry = jar.entries().asSequence().single { it.name == entryName }
-    jar.getInputStream(entry).use { it.readBytes() }
-  }
-
   override fun toString(): String = path.toString()
+}
+
+fun ZipFile.getBytes(entryName: String): ByteArray {
+  return getStream(entryName).use { it.readBytes() }
 }
 
 fun ZipFile.getContent(entryName: String): String {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -14,7 +14,7 @@ import org.objectweb.asm.commons.Remapper
  */
 internal class RelocatorRemapper(
   private val relocators: Set<Relocator>,
-  private val modifiedCallback: () -> Unit = {},
+  private val onModified: () -> Unit = {},
 ) : Remapper() {
   private val classPattern: Pattern = Pattern.compile("(\\[*)?L(.+)")
 
@@ -36,7 +36,7 @@ internal class RelocatorRemapper(
   private fun mapName(name: String, mapLiterals: Boolean = false): String {
     val newName = mapNameImpl(name, mapLiterals)
     if (newName != name) {
-      modifiedCallback()
+      onModified()
     }
     return newName
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -14,6 +14,7 @@ import org.objectweb.asm.commons.Remapper
  */
 internal class RelocatorRemapper(
   private val relocators: Set<Relocator>,
+  private val modifiedCallback: () -> Unit = {},
 ) : Remapper() {
   private val classPattern: Pattern = Pattern.compile("(\\[*)?L(.+)")
 
@@ -33,6 +34,14 @@ internal class RelocatorRemapper(
   }
 
   private fun mapName(name: String, mapLiterals: Boolean = false): String {
+    val newName = mapNameImpl(name, mapLiterals)
+    if (newName != name) {
+      modifiedCallback()
+    }
+    return newName
+  }
+
+  private fun mapNameImpl(name: String, mapLiterals: Boolean): String {
     var newName = name
     var prefix = ""
     var suffix = ""


### PR DESCRIPTION
If we don't need to make any changes to the class, we should use the original bytes instead of letting ASM generate new ones. 
Some tools (e.g. https://plugins.gradle.org/plugin/com.palantir.baseline-class-uniqueness) use (hashes of) class file bytes to determine if there are classpath conflicts, and Shadow's current logic causes false positives.
But even in general, I believe it makes sense to change as little as we can.

A similar change was made to the maven shade plugin at https://github.com/apache/maven-shade-plugin/pull/95.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
