### PR TITLE
docs: Add comprehensive Java 21 migration guide for Minecraft plugin developers

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,5 +1,9 @@
 # Getting Started
 
+!!! info "Migrating from older versions?"
+    If you're migrating from the old `com.github.johnrengelman.shadow` plugin or need Java 21 support, 
+    check out our [Java 21 Migration Guide](java-21-migration.md) for step-by-step instructions.
+
 === "Kotlin"
 
     ```kotlin

--- a/docs/getting-started/java-21-migration.md
+++ b/docs/getting-started/java-21-migration.md
@@ -1,0 +1,221 @@
+# Java 21 Migration Guide
+
+This guide helps you migrate from older Shadow plugin versions to the modern `com.gradleup.shadow` plugin with Java 21 support.
+
+## Overview
+
+With the release of Shadow 9.x and the requirement for Java 21 in many modern projects (like Folia 1.21.8), developers need to migrate from:
+- **Old Plugin ID**: `com.github.johnrengelman.shadow`
+- **New Plugin ID**: `com.gradleup.shadow`
+
+## Migration Steps
+
+### 1. Update Plugin Declaration
+
+=== "Before (Old Plugin)"
+
+    ```kotlin
+    plugins {
+        id("com.github.johnrengelman.shadow") version "8.1.1"
+    }
+    ```
+
+=== "After (New Plugin)"
+
+    ```kotlin
+    plugins {
+        id("com.gradleup.shadow") version "8.3.3" // For Java 21 support
+        // or version "9.1.0" for latest features
+    }
+    ```
+
+### 2. Update Java Version
+
+For Java 21 compatibility, ensure your build configuration targets Java 21:
+
+```kotlin
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+```
+
+### 3. Version Compatibility Matrix
+
+| Shadow Version | Plugin ID | Min Java | Min Gradle | Max Java |
+|----------------|-----------|----------|------------|----------|
+| 8.1.1 | `com.github.johnrengelman.shadow` | 8 | 7.0 | 17 |
+| 8.3.3 | `com.gradleup.shadow` | 11 | 8.3 | 21 |
+| 9.1.0+ | `com.gradleup.shadow` | 11 | 8.3 | 25 |
+
+### 4. Common Issues and Solutions
+
+#### Issue: "UnsupportedClassVersionError"
+**Cause**: Using old Shadow plugin with Java 21  
+**Solution**: Migrate to Shadow 8.3.3+ or 9.x
+
+#### Issue: "Plugin not found"
+**Cause**: Using old plugin ID with newer versions  
+**Solution**: Update plugin ID to `com.gradleup.shadow`
+
+#### Issue: Gradle compatibility warnings
+**Cause**: Version mismatch between Gradle and Shadow  
+**Solution**: Use compatible versions from the matrix above
+
+### 5. Minecraft Plugin Development
+
+For Minecraft plugin developers using Folia, Paper, or Spigot:
+
+=== "Folia 1.21.8+ (Requires Java 21)"
+
+    ```kotlin
+    plugins {
+        id("java")
+        id("com.gradleup.shadow") version "8.3.3"
+    }
+    
+    java {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+    
+    dependencies {
+        compileOnly("dev.folia:folia-api:1.21.8-R0.1-SNAPSHOT")
+        // other dependencies...
+    }
+    
+    tasks {
+        shadowJar {
+            archiveClassifier.set("")
+            relocate("com.example.lib", "your.plugin.lib.example")
+        }
+    }
+    ```
+
+=== "Paper/Spigot (Java 17+)"
+
+    ```kotlin
+    plugins {
+        id("java")
+        id("com.gradleup.shadow") version "8.3.3"
+    }
+    
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    
+    dependencies {
+        compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+        // other dependencies...
+    }
+    ```
+
+### 6. Breaking Changes in 9.x
+
+If migrating to Shadow 9.x, be aware of these breaking changes:
+
+- **`isEnableRelocation`** → **`enableAutoRelocation`**
+- **Default `duplicatesStrategy`**: Changed from `EXCLUDE` to `INCLUDE` (reverted to `EXCLUDE` in 9.0.1)
+- **Transformer interface changes**: Updated to accept context objects
+- **Resource handling**: `from()` behavior aligned with Gradle's `AbstractCopyTask.from`
+
+=== "Shadow 8.x"
+
+    ```kotlin
+    tasks.shadowJar {
+        isEnableRelocation = true
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        mergeServiceFiles()
+    }
+    ```
+
+=== "Shadow 9.x"
+
+    ```kotlin
+    tasks.shadowJar {
+        enableAutoRelocation = true
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Explicitly set
+        mergeServiceFiles()
+    }
+    ```
+
+## Troubleshooting
+
+### Build Cache Issues
+
+If you encounter Gradle cache corruption after migrating:
+
+```bash
+# Clear Gradle cache
+./gradlew clean --refresh-dependencies
+
+# Or manually clear cache
+rm -rf ~/.gradle/caches/
+```
+
+### Dependency Conflicts
+
+When migrating plugins with many dependencies, avoid relocating core platform classes:
+
+```kotlin
+tasks.shadowJar {
+    // DON'T relocate these for Minecraft plugins
+    // relocate("io.papermc", "your.plugin.papermc") // ❌ This breaks Folia schedulers
+    
+    // DO relocate your library dependencies
+    relocate("com.google.gson", "your.plugin.lib.gson") // ✅ Safe to relocate
+}
+```
+
+## Complete Example: UltimateTeams Plugin
+
+Real-world example from a Folia 1.21.8 plugin:
+
+```kotlin
+plugins {
+    kotlin("jvm") version "1.8.0"
+    id("com.gradleup.shadow") version "8.3.3"
+    id("java")
+}
+
+group = "dev.xf3d3"
+version = "4.5.4-folia-1.21.8"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+    // other repositories...
+}
+
+dependencies {
+    compileOnly("dev.folia:folia-api:1.21.8-R0.1-SNAPSHOT")
+    implementation("org.bstats:bstats-bukkit:3.1.0")
+    // other dependencies...
+}
+
+tasks {
+    shadowJar {
+        archiveFileName.set("${rootProject.name}-${rootProject.version}.jar")
+        archiveClassifier.set("main")
+        
+        // Relocate dependencies to avoid conflicts
+        relocate("org.bstats", "dev.xf3d3.ultimateteams.libraries.bstats")
+        relocate("co.aikar", "dev.xf3d3.ultimateteams.libraries.aikar")
+        
+        // IMPORTANT: Don't relocate io.papermc for Folia compatibility
+        // relocate("io.papermc", "...") // ❌ This causes scheduler errors
+    }
+    
+    build {
+        dependsOn(shadowJar)
+    }
+}
+```
+
+This migration ensures compatibility with the latest Minecraft server software while maintaining plugin functionality.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ markdown_extensions:
 nav:
   - 'Introduction': README.md
   - 'Getting Started': getting-started/README.md
+  - 'Java 21 Migration Guide': getting-started/java-21-migration.md
   - 'Configuration':
       - 'Overview': configuration/README.md
       - 'Filtering': configuration/filtering/README.md


### PR DESCRIPTION
## Summary
This PR adds a comprehensive migration guide to help developers transition from the old Shadow plugin to the modern \com.gradleup.shadow\ plugin with Java 21 support.

## Problem Solved
Many developers, especially in the Minecraft plugin community, are struggling with migrating to Java 21 and the new Shadow plugin when updating to modern server software like Folia 1.21.8. The existing documentation lacks clear migration paths and troubleshooting guidance.

## What This Adds

### 📚 New Documentation
- **Java 21 Migration Guide** (\docs/getting-started/java-21-migration.md\)
- Integration with existing navigation structure
- Cross-references from the main Getting Started guide

### 🎯 Key Content
1. **Plugin ID Migration**: \com.github.johnrengelman.shadow\ → \com.gradleup.shadow\
2. **Version Compatibility Matrix**: Clear table showing Java/Gradle/Shadow version compatibility
3. **Step-by-step Migration Instructions**: With before/after code examples
4. **Minecraft-specific Guidance**: Folia, Paper, Spigot configurations
5. **Troubleshooting Section**: Common issues and solutions
6. **Real-world Example**: Complete UltimateTeams plugin configuration

### 🔧 Solutions for Common Issues
- **UnsupportedClassVersionError**: Clear cause and fix
- **Plugin not found errors**: ID migration guidance  
- **Build cache corruption**: Gradle cache clearing instructions
- **Folia scheduler conflicts**: Critical warning about \io.papermc\ relocations
- **Breaking changes in 9.x**: \enableAutoRelocation\ and other API changes

## Target Audience
- Minecraft plugin developers upgrading to Folia 1.21.8 (requires Java 21)
- Any developer migrating from old Shadow plugin versions
- Developers encountering Java version compatibility issues
- Teams updating legacy projects to modern toolchains

## Real-world Validation
This guide is based on actual migration experience with the UltimateTeams plugin, where we successfully:
- ✅ Migrated from Shadow 8.1.1 to 8.3.3
- ✅ Updated Java 17 → Java 21
- ✅ Fixed Folia 1.21.8 scheduler compatibility issues
- ✅ Resolved Gradle cache corruption problems

## Impact
This documentation will help thousands of Minecraft plugin developers smoothly transition to modern toolchains, reducing support requests and migration friction. The guide fills a critical gap in the current documentation ecosystem.