### PR TITLE
Note the breaking change caused by `afterEvaluate` usages

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -52,7 +52,7 @@
 
 - Don't inject `TargetJvmVersion` attribute when automatic JVM targeting is disabled. ([#1666](https://github.com/GradleUp/shadow/pull/1666))
 - Do not write modified class files for no-op relocations. ([#1694](https://github.com/GradleUp/shadow/pull/1694))
-- **BREAKING CHANGE:** As some `afterEvaluate` usages are introduced, this may cause configuration issues in rare cases.
+- **BREAKING CHANGE:** The introduction of some `afterEvaluate` usages may cause configuration issues in rare cases.
 
 ## [9.0.2](https://github.com/GradleUp/shadow/releases/tag/9.0.2) - 2025-08-15
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -52,6 +52,7 @@
 
 - Don't inject `TargetJvmVersion` attribute when automatic JVM targeting is disabled. ([#1666](https://github.com/GradleUp/shadow/pull/1666))
 - Do not write modified class files for no-op relocations. ([#1694](https://github.com/GradleUp/shadow/pull/1694))
+- **BREAKING CHANGE:** As some `afterEvaluate` usages are introduced, this may cause configuration issues in rare cases.
 
 ## [9.0.2](https://github.com/GradleUp/shadow/releases/tag/9.0.2) - 2025-08-15
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -98,18 +98,15 @@ public abstract class ShadowJavaPlugin @Inject constructor(
     shadowComponent.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
       variant.mapToMavenScope("runtime")
     }
-    // Must use afterEvaluate here as we need to track the changes of addShadowVariantIntoJavaComponent.
-    afterEvaluate {
+    components.named("java", AdhocComponentWithVariants::class.java) {
       if (shadow.addShadowVariantIntoJavaComponent.get()) {
         logger.info("Adding ${shadowRuntimeElements.name} variant to Java component.")
       } else {
         logger.info("Skipping adding ${shadowRuntimeElements.name} variant to Java component.")
-        return@afterEvaluate
+        return@named
       }
-      components.named("java", AdhocComponentWithVariants::class.java) {
-        it.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
-          variant.mapToOptional()
-        }
+      it.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
+        variant.mapToOptional()
       }
     }
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -98,15 +98,18 @@ public abstract class ShadowJavaPlugin @Inject constructor(
     shadowComponent.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
       variant.mapToMavenScope("runtime")
     }
-    components.named("java", AdhocComponentWithVariants::class.java) {
+    // Must use afterEvaluate here as we need to track the changes of addShadowVariantIntoJavaComponent.
+    afterEvaluate {
       if (shadow.addShadowVariantIntoJavaComponent.get()) {
         logger.info("Adding ${shadowRuntimeElements.name} variant to Java component.")
       } else {
         logger.info("Skipping adding ${shadowRuntimeElements.name} variant to Java component.")
-        return@named
+        return@afterEvaluate
       }
-      it.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
-        variant.mapToOptional()
+      components.named("java", AdhocComponentWithVariants::class.java) {
+        it.addVariantsFromConfiguration(shadowRuntimeElements) { variant ->
+          variant.mapToOptional()
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #1718.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
