### PR TITLE
Move injecting `Main-Class` manifest attr logic from `doFirst` into `copy`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -204,6 +204,7 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar
 	public fun getFailOnDuplicateEntries ()Lorg/gradle/api/provider/Property;
 	public fun getIncludedDependencies ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getIncludes ()Ljava/util/Set;
+	public fun getMainClass ()Lorg/gradle/api/provider/Property;
 	public fun getManifest ()Lcom/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest;
 	public synthetic fun getManifest ()Lorg/gradle/api/java/archives/Manifest;
 	public fun getMinimizeJar ()Lorg/gradle/api/provider/Property;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -8,6 +8,7 @@
 - Support relocating Groovy extensions in Module descriptors. ([#1705](https://github.com/GradleUp/shadow/pull/1705))
 - Add extensions for `Iterable<Relocator>`. ([#1710](https://github.com/GradleUp/shadow/pull/1710))
 - Support relocating list of types in `RelocatorRemapper`. ([#1714](https://github.com/GradleUp/shadow/pull/1714))
+- Add `mainClass` property into `ShadowJar`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
 
 ### Changed
 
@@ -15,6 +16,7 @@
   The Gradle Module descriptors (`org.codehaus.groovy.runtime.ExtensionModule` files) defined under `META-INF/services/`
   and `META-INF/groovy` will be merged into `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule`.
 - Move injecting `Class-Path` manifest attr logic from `doFirst` into `copy`. ([#1720](https://github.com/GradleUp/shadow/pull/1720))
+- Move injecting `Main-Class` manifest attr logic from `doFirst` into `copy`. ([#1724](https://github.com/GradleUp/shadow/pull/1724))
 - Deprecate `InheritManifest`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
 
 ### Fixed

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -9,6 +9,12 @@
 - Add extensions for `Iterable<Relocator>`. ([#1710](https://github.com/GradleUp/shadow/pull/1710))
 - Support relocating list of types in `RelocatorRemapper`. ([#1714](https://github.com/GradleUp/shadow/pull/1714))
 - Add `mainClass` property into `ShadowJar`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
+  ```kotlin
+  tasks.shadowJar {
+    // This property will be used as a fallback if there is no explicit `Main-Class` attribute set.
+    mainClass = "my.Main"
+  }
+  ```
 
 ### Changed
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -154,6 +154,7 @@ Here are the options that can be passed to the `shadowJar`:
 --no-enable-auto-relocation         Disables option --enable-auto-relocation.
 --fail-on-duplicate-entries         Fails build if the ZIP entries in the shadowed JAR are duplicate.
 --no-fail-on-duplicate-entries      Disables option --fail-on-duplicate-entries.
+--main-class                        Main class attribute to add to manifest.
 --minimize-jar                      Minimizes the jar by removing unused classes.
 --no-minimize-jar                   Disables option --minimize-jar.
 --relocation-prefix                 Prefix used for auto relocation of packages in the dependencies.

--- a/gradle/lint-baseline.xml
+++ b/gradle/lint-baseline.xml
@@ -85,7 +85,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt"
-            line="73"
+            line="72"
             column="9"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt"
-            line="74"
+            line="73"
             column="9"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt"
-            line="75"
+            line="74"
             column="9"/>
     </issue>
 
@@ -118,7 +118,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt"
-            line="76"
+            line="75"
             column="9"/>
     </issue>
 
@@ -184,7 +184,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt"
-            line="43"
+            line="44"
             column="1"/>
     </issue>
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
@@ -171,6 +171,24 @@ class ApplicationPluginTest : BasePluginTest() {
   }
 
   @Test
+  fun overrideMainClassFromApplicationPlugin() {
+    prepare()
+    projectScript.appendText(
+      """
+        $shadowJarTask {
+          mainClass = 'my.Main2' // Different from application.mainClass.
+        }
+      """.trimIndent(),
+    )
+
+    run(runShadowPath) // Run without errors.
+
+    assertThat(jarPath("build/libs/myapp-1.0-all.jar")).useAll {
+      getMainAttr(mainClassAttributeKey).isEqualTo("my.Main2")
+    }
+  }
+
+  @Test
   fun errorWhenMainClassNotSet() {
     prepare(mainClassBlock = "")
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/ApplicationPluginTest.kt
@@ -177,8 +177,7 @@ class ApplicationPluginTest : BasePluginTest() {
     val result = runWithFailure(runShadowPath)
 
     assertThat(result.output).contains(
-      "Error: Could not find or load main class",
-      "Caused by: java.lang.ClassNotFoundException:",
+      "no main manifest attribute, in",
     )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -104,6 +104,7 @@ class JavaPluginsTest : BasePluginTest() {
       assertThat(enableAutoRelocation.get()).isFalse()
       assertThat(failOnDuplicateEntries.get()).isFalse()
       assertThat(minimizeJar.get()).isFalse()
+      assertThat(mainClass.orNull).isNull()
 
       assertThat(relocationPrefix.get()).isEqualTo(ShadowBasePlugin.SHADOW)
       assertThat(configurations.get()).all {
@@ -126,6 +127,7 @@ class JavaPluginsTest : BasePluginTest() {
       "--no-enable-auto-relocation     Disables option --enable-auto-relocation.",
       "--fail-on-duplicate-entries     Fails build if the ZIP entries in the shadowed JAR are duplicate.",
       "--no-fail-on-duplicate-entries     Disables option --fail-on-duplicate-entries",
+      "--main-class     Main class attribute to add to manifest.",
       "--minimize-jar     Minimizes the jar by removing unused classes.",
       "--no-minimize-jar     Disables option --minimize-jar.",
       "--relocation-prefix     Prefix used for auto relocation of packages in the dependencies.",

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -6,7 +6,6 @@ import com.github.jengelman.gradle.plugins.shadow.internal.applicationExtension
 import com.github.jengelman.gradle.plugins.shadow.internal.distributions
 import com.github.jengelman.gradle.plugins.shadow.internal.javaPluginExtension
 import com.github.jengelman.gradle.plugins.shadow.internal.javaToolchainService
-import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.internal.requireResourceAsText
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.shadowJar
 import org.gradle.api.GradleException
@@ -127,20 +126,8 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
   }
 
   protected open fun Project.configureShadowJarMainClass() {
-    // Default to empty string to avoid the error of the value not being configured yet.
-    val mainClassName = applicationExtension.mainClass.convention("")
     tasks.shadowJar.configure { task ->
-      task.inputs.property("mainClassName", mainClassName)
-      task.doFirst("Set $mainClassAttributeKey attribute in the manifest") {
-        // Inject the attribute if it is not already present.
-        if (!task.manifest.attributes.contains(mainClassAttributeKey)) {
-          val realClass = mainClassName.orNull
-          if (realClass.isNullOrEmpty()) {
-            error("The main class must be specified and not left empty in `application.mainClass` or manifest attributes.")
-          }
-          task.manifest.attributes[mainClassAttributeKey] = realClass
-        }
-      }
+      task.mainClass.convention(applicationExtension.mainClass)
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowKmpPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowKmpPlugin.kt
@@ -1,7 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.internal.isAtLeastKgpVersion
-import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.SHADOW_JAR_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.registerShadowJarCommon
 import org.gradle.api.Plugin
@@ -41,15 +40,7 @@ public abstract class ShadowKmpPlugin : Plugin<Project> {
 
       @OptIn(ExperimentalKotlinGradlePluginApi::class)
       target.mainRun {
-        // Fix cannot serialize object of type 'org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmRun'.
-        val mainClassName = provider { mainClass }
-        task.inputs.property("mainClassName", mainClassName)
-        task.doFirst("Set $mainClassAttributeKey attribute in the manifest") {
-          val realClass = mainClassName.get().orNull
-          if (!task.manifest.attributes.contains(mainClassAttributeKey) && !realClass.isNullOrEmpty()) {
-            task.manifest.attributes[mainClassAttributeKey] = realClass
-          }
-        }
+        task.mainClass.convention(mainClass)
       }
     }
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -198,7 +198,7 @@ public abstract class ShadowJar : Jar() {
   /**
    * Main class attribute to add to the manifest of the shadow JAR.
    *
-   * This property will be fell back if there is no explicit `Main-Class` attribute set for the [ShadowJar] task or the
+   * This property will be used as a fallback if there is no explicit `Main-Class` attribute set for the [ShadowJar] task or the
    * main [Jar] task.
    *
    * Defaults to `null`.

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -466,13 +466,15 @@ public abstract class ShadowJar : Jar() {
     }
 
   private fun injectManifestAttributes() {
-    if (manifest.attributes.contains(mainClassAttributeKey)) {
-      logger.info("Skipping adding $mainClassAttributeKey attribute to the manifest as it is already set.")
-    } else {
-      val mainClassValue = mainClass.orNull
-      if (mainClassValue.isNullOrEmpty()) {
+    val mainClassValue = mainClass.orNull
+    when {
+      manifest.attributes.contains(mainClassAttributeKey) -> {
+        logger.info("Skipping adding $mainClassAttributeKey attribute to the manifest as it is already set.")
+      }
+      mainClassValue.isNullOrEmpty() -> {
         logger.info("Skipping adding $mainClassAttributeKey attribute to the manifest as it is empty.")
-      } else {
+      }
+      else -> {
         manifest.attributes[mainClassAttributeKey] = mainClassValue
         logger.info("Adding $mainClassAttributeKey attribute to the manifest with value '$mainClassValue'.")
       }


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
