### PR TITLE
Update `RelocatorRemapper` class pattern to cover more cases

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -65,6 +65,9 @@ internal class RelocatorRemapper(
   }
 
   private companion object {
-    val classPattern: Pattern = Pattern.compile("([\\[()]*)?L([^;]+);?")
+    /**
+     * https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html
+     */
+    val classPattern: Pattern = Pattern.compile("([\\[()BCDFIJSZ]*)?L([^;]+);?")
   }
 }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocatorRemapperTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocatorRemapperTest.kt
@@ -36,6 +36,22 @@ class RelocatorRemapperTest {
       Arguments.of("(Lorg/package/ClassA;Lorg/package/ClassB;)", "(Lshadow/org/package/ClassA;Lshadow/org/package/ClassB;)"),
       // Method return types.
       Arguments.of("()Lorg/package/ClassA;Lorg/package/ClassB;", "()Lshadow/org/package/ClassA;Lshadow/org/package/ClassB;"),
+      // void method(byte arg1, org.package.ClassA arg2)
+      Arguments.of("(BLorg/package/ClassA;)V", "(BLshadow/org/package/ClassA;)V"),
+      // void method(char arg1, org.package.ClassA arg2)
+      Arguments.of("(CLorg/package/ClassA;)V", "(CLshadow/org/package/ClassA;)V"),
+      // void method(double arg1, org.package.ClassA arg2)
+      Arguments.of("(DLorg/package/ClassA;)V", "(DLshadow/org/package/ClassA;)V"),
+      // void method(float arg1, org.package.ClassA arg2)
+      Arguments.of("(FLorg/package/ClassA;)V", "(FLshadow/org/package/ClassA;)V"),
+      // void method(int arg1, org.package.ClassA arg2)
+      Arguments.of("(ILorg/package/ClassA;)V", "(ILshadow/org/package/ClassA;)V"),
+      // void method(long arg1, org.package.ClassA arg2)
+      Arguments.of("(JLorg/package/ClassA;)V", "(JLshadow/org/package/ClassA;)V"),
+      // void method(short arg1, org.package.ClassA arg2)
+      Arguments.of("(SLorg/package/ClassA;)V", "(SLshadow/org/package/ClassA;)V"),
+      // void method(boolean arg1, org.package.ClassA arg2)
+      Arguments.of("(ZLorg/package/ClassA;)V", "(ZLshadow/org/package/ClassA;)V"),
     )
   }
 }


### PR DESCRIPTION
https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html

Closes #1730.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
