### PR TITLE
Test single method argument in `relocateSignaturePatterns`

### DIFF
--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocatorRemapperTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocatorRemapperTest.kt
@@ -39,6 +39,8 @@ class RelocatorRemapperTest {
       Arguments.of("Lorg/package/ClassA;Lorg/package/ClassB;", "Lshadow/org/package/ClassA;Lshadow/org/package/ClassB;"),
       // Multiple classes.
       Arguments.of("Ljava/lang/Object;Lorg/package/ClassB;", "Ljava/lang/Object;Lshadow/org/package/ClassB;"),
+      // Single method argument.
+      Arguments.of("(Lorg/package/ClassA;)", "(Lshadow/org/package/ClassA;)"),
       // Method arguments.
       Arguments.of("(Lorg/package/ClassA;Lorg/package/ClassB;)", "(Lshadow/org/package/ClassA;Lshadow/org/package/ClassB;)"),
       // Method return types.


### PR DESCRIPTION
Closes #777.