### PR TITLE
Make assemble depend on shadowJar even if it is added later

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -519,7 +519,7 @@ public abstract class ShadowJar : Jar() {
       jarTask: TaskProvider<Jar>,
       action: (ShadowJar) -> Unit,
     ): TaskProvider<ShadowJar> {
-      return tasks.register(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) { task ->
+      val task = tasks.register(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) { task ->
         task.archiveClassifier.set("all")
         task.exclude(
           "META-INF/INDEX.LIST",
@@ -537,11 +537,14 @@ public abstract class ShadowJar : Jar() {
           jarTask.get().manifest,
         )
 
-        @Suppress("EagerGradleConfiguration") // Can't use `named` as the task is optional.
-        tasks.findByName(LifecycleBasePlugin.ASSEMBLE_TASK_NAME)?.dependsOn(task)
-
         action(task)
       }
+
+      // Can't use `named` directly as the task is optional or may not exist when the plugin is applied.
+      // Using Spec<String> applies the action to the task if it is added later.
+      tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME::equals).configureEach { it.dependsOn(task) }
+
+      return task
     }
   }
 }


### PR DESCRIPTION
Currently, Shadow makes the assemble task depend on shadowJar if and only if it exists when the shadow plugin is applied. This is usually fine, but in the case of some unorthodox setups, it can mean that if the Shadow plugin is applied before the base plugin, the assemble task can end up existing without depending on the shadowJar task.

To address this, instead of using `TaskContainer#findByName(String)`, we can use `#named(Spec<String>)` to work with a live view of the container. This is very similar to how `#withType(Class<S extends T>` works, where `configureEach` applies the action to each member that passes the spec, even if it is added later.

The only thing I don't know what to do now with this PR is how to write tests for it. I'd appreciate your help with that. Thanks!

---

For the record, you can easily test this using this snipped. Apologies for the Groovy DSL :stuck_out_tongue:

```groovy
println "findByName testTask2 = ${tasks.findByName('testTask2')}"
tasks.named ({ 'testTask2'.equals(it) } as Spec<String>).configureEach {
    println "named(spec) testTask2 = $it"
}

println 'Registering testTask2'
tasks.register('testTask2')

println "findByName testTask2 = ${tasks.findByName('testTask2')}"
tasks.named ({ 'testTask2'.equals(it) } as Spec<String>).configureEach {
    println "named(spec) testTask2 = $it"
}
```

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
