### PR TITLE
TODO usages of `conventionMapping`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -32,7 +32,6 @@
 - Bump min Java requirement to 17. ([#1744](https://github.com/GradleUp/shadow/pull/1744))
 - Require most optional properties non-null. ([#1745](https://github.com/GradleUp/shadow/pull/1745))
 - Make assemble depend on shadowJar even if it is added later. ([#1766](https://github.com/GradleUp/shadow/pull/1766))
-- Remove `conventionMapping` usages. ([#1770](https://github.com/GradleUp/shadow/pull/1770))
 
 ### Fixed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -32,6 +32,7 @@
 - Bump min Java requirement to 17. ([#1744](https://github.com/GradleUp/shadow/pull/1744))
 - Require most optional properties non-null. ([#1745](https://github.com/GradleUp/shadow/pull/1745))
 - Make assemble depend on shadowJar even if it is added later. ([#1766](https://github.com/GradleUp/shadow/pull/1766))
+- Remove `conventionMapping` usages. ([#1770](https://github.com/GradleUp/shadow/pull/1770))
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -58,13 +58,14 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
 
       task.classpath = files(tasks.shadowJar)
 
+      @Suppress("InternalGradleApiUsage") // Usages of conventionMapping.
       with(applicationExtension) {
         task.mainModule.convention(mainModule)
         task.mainClass.convention(mainClass)
-        task.applicationName = applicationName
-        task.outputDir = layout.buildDirectory.dir("scriptsShadow").get().asFile
-        task.executableDir = executableDir
-        task.defaultJvmOpts = applicationDefaultJvmArgs
+        task.conventionMapping.map("applicationName", ::getApplicationName)
+        task.conventionMapping.map("outputDir") { layout.buildDirectory.dir("scriptsShadow").get().asFile }
+        task.conventionMapping.map("executableDir", ::getExecutableDir)
+        task.conventionMapping.map("defaultJvmOpts", ::getApplicationDefaultJvmArgs)
       }
       task.modularity.inferModulePath.convention(javaPluginExtension.modularity.inferModulePath)
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -58,14 +58,13 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
 
       task.classpath = files(tasks.shadowJar)
 
-      @Suppress("InternalGradleApiUsage") // Usages of conventionMapping.
       with(applicationExtension) {
         task.mainModule.convention(mainModule)
         task.mainClass.convention(mainClass)
-        task.conventionMapping.map("applicationName", ::getApplicationName)
-        task.conventionMapping.map("outputDir") { layout.buildDirectory.dir("scriptsShadow").get().asFile }
-        task.conventionMapping.map("executableDir", ::getExecutableDir)
-        task.conventionMapping.map("defaultJvmOpts", ::getApplicationDefaultJvmArgs)
+        task.applicationName = applicationName
+        task.outputDir = layout.buildDirectory.dir("scriptsShadow").get().asFile
+        task.executableDir = executableDir
+        task.defaultJvmOpts = applicationDefaultJvmArgs
       }
       task.modularity.inferModulePath.convention(javaPluginExtension.modularity.inferModulePath)
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowApplicationPlugin.kt
@@ -58,7 +58,7 @@ public abstract class ShadowApplicationPlugin : Plugin<Project> {
 
       task.classpath = files(tasks.shadowJar)
 
-      @Suppress("InternalGradleApiUsage") // Usages of conventionMapping.
+      @Suppress("InternalGradleApiUsage") // TODO: replace usages of conventionMapping.
       with(applicationExtension) {
         task.mainModule.convention(mainModule)
         task.mainClass.convention(mainClass)


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
