### PR TITLE
Fix the regression of inheriting manifest from jar task again

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -702,7 +702,10 @@ class JavaPluginsTest : BasePluginTest() {
           }
         }
         $shadowJarTask {
-          manifest.from(testJar.get().manifest)
+          manifest {
+            attributes 'Baz-Attr': 'Baz-Value'
+            from(testJar.get().manifest)
+          }
         }
       """.trimIndent(),
     )
@@ -713,6 +716,7 @@ class JavaPluginsTest : BasePluginTest() {
       transform { it.mainAttrSize }.isGreaterThan(2)
       getMainAttr("Foo-Attr").isEqualTo("Foo-Value")
       getMainAttr("Bar-Attr").isEqualTo("Bar-Value")
+      getMainAttr("Baz-Attr").isEqualTo("Baz-Value")
     }
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -716,6 +716,32 @@ class JavaPluginsTest : BasePluginTest() {
     }
   }
 
+  @Issue(
+    "https://github.com/GradleUp/shadow/issues/1781",
+  )
+  @Test
+  fun inheritManifestFromJarAgain() {
+    projectScript.appendText(
+      """
+        $jarTask {
+          manifest {
+            attributes 'Foo-Attr': 'Foo-Value'
+          }
+        }
+        $shadowJarTask {
+          manifest.from($jarTask.get().manifest)
+        }
+      """.trimIndent(),
+    )
+
+    run(shadowJarPath)
+
+    assertThat(outputShadowedJar).useAll {
+      transform { it.mainAttrSize }.isGreaterThan(2)
+      getMainAttr("Foo-Attr").isEqualTo("Foo-Value")
+    }
+  }
+
   @Test
   fun inheritManifestMainClassFromJar() {
     projectScript.appendText(

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.contains
 import assertk.assertions.containsMatch
 import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
-import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
@@ -512,7 +511,7 @@ class JavaPluginsTest : BasePluginTest() {
     assertThat(outputShadowedJar).useAll {
       transform { actual -> actual.entries().toList().map { it.name }.filter { it.endsWith(".class") } }
         .single().isEqualTo("my/plugin/MyPlugin.class")
-      transform { it.mainAttrSize }.isGreaterThan(0)
+      transform { it.mainAttrSize }.isEqualTo(1)
       // Doesn't contain Gradle classes.
       getMainAttr(classPathAttributeKey).isNull()
 
@@ -713,7 +712,7 @@ class JavaPluginsTest : BasePluginTest() {
     run(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      transform { it.mainAttrSize }.isGreaterThan(2)
+      transform { it.mainAttrSize }.isEqualTo(4)
       getMainAttr("Foo-Attr").isEqualTo("Foo-Value")
       getMainAttr("Bar-Attr").isEqualTo("Bar-Value")
       getMainAttr("Baz-Attr").isEqualTo("Baz-Value")
@@ -741,7 +740,7 @@ class JavaPluginsTest : BasePluginTest() {
     run(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      transform { it.mainAttrSize }.isGreaterThan(2)
+      transform { it.mainAttrSize }.isEqualTo(2)
       getMainAttr("Foo-Attr").isEqualTo("Foo-Value")
     }
   }
@@ -767,7 +766,7 @@ class JavaPluginsTest : BasePluginTest() {
       "Skipping adding $mainClassAttributeKey attribute to the manifest as it is already set.",
     )
     assertThat(outputShadowedJar).useAll {
-      transform { it.mainAttrSize }.isGreaterThan(1)
+      transform { it.mainAttrSize }.isEqualTo(2)
       getMainAttr("Main-Class").isEqualTo("my.Main")
     }
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultInheritManifest.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultInheritManifest.kt
@@ -14,11 +14,10 @@ import org.gradle.api.java.archives.internal.DefaultManifestMergeSpec
 
 internal class DefaultInheritManifest(
   project: Project,
-  manifest: Manifest? = null,
   // `AbstractTask.getServices` is protected, we need to get it via `DefaultProject`.
   // https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L194
   private val fileResolver: FileResolver = (project as DefaultProject).services.get(FileResolver::class.java),
-  private val internalManifest: Manifest = manifest ?: DefaultManifest(fileResolver),
+  private val internalManifest: Manifest = DefaultManifest(fileResolver),
 ) : InheritManifest,
   Manifest by internalManifest {
   private val inheritMergeSpecs = mutableListOf<DefaultManifestMergeSpec>()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -530,13 +530,8 @@ public abstract class ShadowJar : Jar() {
           "META-INF/versions/**/module-info.class",
           "module-info.class",
         )
-
-        task.manifest = DefaultInheritManifest(
-          project,
-          @Suppress("EagerGradleConfiguration") // The ctor doesn't support Provider.
-          jarTask.get().manifest,
-        )
-
+        @Suppress("EagerGradleConfiguration") // manifest is not a lazy property.
+        task.manifest.from(jarTask.get().manifest)
         action.execute(task)
       }.also { task ->
         // Can't use `named` directly as the task is optional or may not exist when the plugin is applied.

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -530,8 +530,8 @@ public abstract class ShadowJar : Jar() {
           "META-INF/versions/**/module-info.class",
           "module-info.class",
         )
-        @Suppress("EagerGradleConfiguration") // manifest is not a lazy property.
-        task.manifest.from(jarTask.get().manifest)
+        @Suppress("EagerGradleConfiguration", "DEPRECATION") // manifest is not a lazy property.
+        task.manifest.inheritFrom(jarTask.get().manifest)
         action.execute(task)
       }.also { task ->
         // Can't use `named` directly as the task is optional or may not exist when the plugin is applied.


### PR DESCRIPTION
Closes #1781.

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
