### PR TITLE
Fix the regression of registering `ShadowJar` tasks without `ShadowPlugin` applied

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.2.1...HEAD) - 2025-xx-xx
 
+## Fixed
+
+- Fix the regression of registering `ShadowJar` tasks without `ShadowPlugin` applied. ([#1787](https://github.com/GradleUp/shadow/pull/1787))
 
 ## [9.2.1](https://github.com/GradleUp/shadow/compare/9.2.0) - 2025-09-24
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -144,13 +144,14 @@ abstract class BasePluginTest {
     plugin: String = "java",
     withGroup: Boolean = false,
     withVersion: Boolean = false,
+    applyShadowPlugin: Boolean = true,
   ): String {
     val groupInfo = if (withGroup) "group = 'my'" else ""
     val versionInfo = if (withVersion) "version = '1.0'" else ""
     return """
       plugins {
         id '$plugin'
-        id '$shadowPluginId'
+        id '$shadowPluginId' apply $applyShadowPlugin
       }
       $groupInfo
       $versionInfo

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -627,10 +627,10 @@ class JavaPluginsTest : BasePluginTest() {
           }
         }
         afterEvaluate {
-          def hasShadowPlugin = project.plugins.findPlugin('${ShadowPlugin::class.qualifiedName}')
-          def hasShadowBasePlugin = project.plugins.findPlugin('${ShadowBasePlugin::class.qualifiedName}')
-          logger.lifecycle("Has Shadow plugin: " + (hasShadowPlugin != null))
-          logger.lifecycle("Has Shadow Base plugin: " + (hasShadowBasePlugin != null))
+          def hasShadowPlugin = plugins.hasPlugin('${ShadowPlugin::class.qualifiedName}')
+          def hasShadowBasePlugin = plugins.hasPlugin('${ShadowBasePlugin::class.qualifiedName}')
+          logger.lifecycle("Has ShadowPlugin: " + hasShadowPlugin)
+          logger.lifecycle("Has ShadowBasePlugin: " + hasShadowBasePlugin)
         }
       """.trimIndent(),
     )
@@ -638,8 +638,8 @@ class JavaPluginsTest : BasePluginTest() {
     val result = run(testShadowJarTask)
 
     assertThat(result.output).contains(
-      "Has Shadow plugin: false",
-      "Has Shadow Base plugin: false",
+      "Has ShadowPlugin: false",
+      "Has ShadowBasePlugin: false",
     )
 
     assertThat(jarPath("build/libs/my-1.0-test.jar")).useAll {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -605,6 +605,62 @@ class JavaPluginsTest : BasePluginTest() {
   }
 
   @Issue(
+    "https://github.com/GradleUp/shadow/issues/1784",
+  )
+  @Test
+  fun registerShadowJarTaskWithoutShadowPluginApplied() {
+    val mainClassEntry = writeClass(sourceSet = "test", withImports = true)
+    val testShadowJarTask = "testShadowJar"
+    projectScript.writeText(
+      """
+        ${getDefaultProjectBuildScript(withGroup = true, withVersion = true, applyShadowPlugin = false)}
+        dependencies {
+          testImplementation 'junit:junit:3.8.2'
+        }
+        def $testShadowJarTask = tasks.register('$testShadowJarTask', ${ShadowJar::class.java.name}) {
+          description = 'Create a combined JAR of project and test dependencies'
+          archiveClassifier = 'test'
+          from sourceSets.named('test').map { it.output }
+          configurations = project.configurations.named('testRuntimeClasspath').map { [it] }
+          manifest {
+            attributes '$mainClassAttributeKey': 'my.Main'
+          }
+        }
+        afterEvaluate {
+          def hasShadowPlugin = project.plugins.findPlugin('${ShadowPlugin::class.qualifiedName}')
+          def hasShadowBasePlugin = project.plugins.findPlugin('${ShadowBasePlugin::class.qualifiedName}')
+          logger.lifecycle("Has Shadow plugin: " + (hasShadowPlugin != null))
+          logger.lifecycle("Has Shadow Base plugin: " + (hasShadowBasePlugin != null))
+        }
+      """.trimIndent(),
+    )
+
+    val result = run(testShadowJarTask)
+
+    assertThat(result.output).contains(
+      "Has Shadow plugin: false",
+      "Has Shadow Base plugin: false",
+    )
+
+    assertThat(jarPath("build/libs/my-1.0-test.jar")).useAll {
+      containsOnly(
+        "my/",
+        mainClassEntry,
+        *junitEntries,
+        *manifestEntries,
+      )
+      getMainAttr(mainClassAttributeKey).isNotNull()
+    }
+
+    val pathString = path("build/libs/my-1.0-test.jar").toString()
+    val runningOutput = runProcess("java", "-jar", pathString, "foo")
+    assertThat(runningOutput).contains(
+      "Hello, World! (foo) from Main",
+      "Refs: junit.framework.Test",
+    )
+  }
+
+  @Issue(
     "https://github.com/GradleUp/shadow/issues/443",
   )
   @Test

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -64,7 +64,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 public abstract class ShadowJar : Jar() {
   private val dependencyFilterForMinimize = MinimizeDependencyFilter(project)
   private val shadowDependencies = project.provider {
-    // Find shadow configuration here instead of get, as the ShadowJar task could be registered without Shadow plugin applied.
+    // Find shadow configuration here instead of get, as the ShadowJar tasks could be registered without Shadow plugin applied.
     project.configurations.findByName(ShadowBasePlugin.CONFIGURATION_NAME) ?: project.files()
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -63,7 +63,10 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 @CacheableTask
 public abstract class ShadowJar : Jar() {
   private val dependencyFilterForMinimize = MinimizeDependencyFilter(project)
-  private val shadowDependencies = project.provider { project.files(project.configurations.shadow) }
+  private val shadowDependencies = project.provider {
+    // Find shadow configuration here instead of get, as the ShadowJar task could be registered without Shadow plugin applied.
+    project.configurations.findByName(ShadowBasePlugin.CONFIGURATION_NAME) ?: project.files()
+  }
 
   init {
     group = LifecycleBasePlugin.BUILD_GROUP


### PR DESCRIPTION
Closes #1784.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
