### PR TITLE
Don't let `ApacheLicenseResourceTransformer` remove `META-INF/LICENSE*`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -8,6 +8,7 @@
 - Change the group of `startShadowScripts` from `application` to `other`. ([#1797](https://github.com/GradleUp/shadow/pull/1797))
 - Update ASM and jdependency to support Java 26. ([#1799](https://github.com/GradleUp/shadow/pull/1799))
 - Bump min Gradle requirement to 9.0.0. ([#1801](https://github.com/GradleUp/shadow/pull/1801))
+- Fix `ApacheLicenseResourceTransformer` to not remove `META-INF/LICENSE*` files ([#1842](https://github.com/GradleUp/shadow/pull/1842))
 
 ## [9.2.2](https://github.com/GradleUp/shadow/compare/9.2.2) - 2025-09-26
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -1,6 +1,14 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
+import com.github.jengelman.gradle.plugins.shadow.internal.property
+import com.github.jengelman.gradle.plugins.shadow.internal.zipEntry
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
+import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 
 /**
  * Prevents duplicate copies of the license.
@@ -10,12 +18,53 @@ import org.gradle.api.file.FileTreeElement
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ApacheLicenseResourceTransformer : ResourceTransformer by ResourceTransformer.Companion {
+public open class ApacheLicenseResourceTransformer @Inject constructor(
+  final override val objectFactory: ObjectFactory,
+) : ResourceTransformer by ResourceTransformer.Companion {
+
+  private val elements: MutableSet<String> = LinkedHashSet()
+
+  /**
+   * The file encoding of the `LICENSE` file.
+   */
+  @get:Input
+  public open val charsetName: Property<String> = objectFactory.property(Charsets.UTF_8.name())
+
+  /**
+   * The separator placed between two licenses.
+   */
+  @get:Input
+  public open val separator: Property<String> = objectFactory.property("\n\n${"-".repeat(120)}\n\n")
+
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val path = element.path
     return LICENSE_PATH.equals(path, ignoreCase = true) ||
       LICENSE_TXT_PATH.regionMatches(0, path, 0, LICENSE_TXT_PATH.length, ignoreCase = true) ||
       LICENSE_MD_PATH.regionMatches(0, path, 0, LICENSE_MD_PATH.length, ignoreCase = true)
+  }
+
+  override fun transform(context: TransformerContext) {
+    val bytes = context.inputStream.readAllBytes()
+    val content = bytes.toString(StandardCharsets.UTF_8).trim('\n', '\r')
+    if (!content.isEmpty()) {
+      elements.add(content)
+    }
+  }
+
+  override fun hasTransformedResource(): Boolean = true
+
+  override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
+    os.putNextEntry(zipEntry(LICENSE_PATH, preserveFileTimestamps))
+    var first = true
+    val separator = separator.get().toByteArray(StandardCharsets.UTF_8)
+    for (element in elements) {
+      if (!first) {
+        os.write(separator)
+      }
+      os.write(element.toByteArray(StandardCharsets.UTF_8))
+      first = false
+    }
+    os.closeEntry()
   }
 
   private companion object {

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.kt
@@ -1,8 +1,13 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+import java.util.zip.ZipInputStream
+import org.apache.tools.zip.ZipOutputStream
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,5 +27,35 @@ class ApacheLicenseResourceTransformerTest : BaseTransformerTest<ApacheLicenseRe
     assertThat(transformer.canTransformResource("META-INF/LICENSE.md")).isTrue()
     assertThat(transformer.canTransformResource("META-INF/License.md")).isTrue()
     assertThat(transformer.canTransformResource("META-INF/MANIFEST.MF")).isFalse()
+  }
+
+  @Test
+  fun licensesAreIncluded() {
+    val baos = ByteArrayOutputStream()
+    val zos = ZipOutputStream(baos)
+
+    transformer.separator.set("\n---\n")
+    transformer.transform(TransformerContext("META-INF/LICENSE", "License 1".byteInputStream()))
+    transformer.transform(TransformerContext("META-INF/LICENSE.txt", "License 2".byteInputStream()))
+    transformer.transform(TransformerContext("META-INF/LICENSE.md", "License 3".byteInputStream()))
+    transformer.transform(TransformerContext("META-INF/LICENSE.txt", "License 1".byteInputStream()))
+    transformer.transform(TransformerContext("META-INF/LICENSE.txt", "\n\r\nLicense 2".byteInputStream()))
+    transformer.transform(TransformerContext("META-INF/LICENSE.txt", "\n\r\nLicense 2\n\r\n".byteInputStream()))
+    transformer.modifyOutputStream(zos, false)
+    zos.close()
+
+    val zis = ZipInputStream(baos.toByteArray().inputStream())
+    zis.nextEntry
+    val output = zis.readAllBytes().toString(Charset.forName(transformer.charsetName.get()))
+
+    assertThat(output).isEqualTo(
+      """
+      License 1
+      ---
+      License 2
+      ---
+      License 3
+      """.trimIndent(),
+    )
   }
 }


### PR DESCRIPTION
The `ApacheLicenseResourceTransformer` effectively removes all `META-INF/LICENSE*` files from the resulting jar.

This change _changes_ the behavior of `ApacheLicenseResourceTransformer` to concatenate the included license files. Identical license texts are included once.

Adapted the `ApacheLicenseResourceTransformerTest` for this change.

Fixes #1842

---

- [X] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
