### PR TITLE
PreserveFirstFoundResourceTransformer smoke test

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformerTest.kt
@@ -24,7 +24,7 @@ class PreserveFirstFoundResourceTransformerTest : BaseTransformerTest() {
         dependenciesBlock = implementationFiles(one, two),
         transformerBlock = """
         exclude("multiple-contents")
-      """.trimIndent(),
+        """.trimIndent(),
       ),
     )
 


### PR DESCRIPTION
Literally just a smoke test to make sure the transformer starts in Gradle builds.

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
