### PR TITLE
Add `FindResourceInClasspath` task to find resources in dependencies

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -176,6 +176,25 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/Dependenc
 	public fun resolve (Lorg/gradle/api/artifacts/Configuration;)Lorg/gradle/api/file/FileCollection;
 }
 
+public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath : org/gradle/api/DefaultTask, org/gradle/api/tasks/util/PatternFilterable {
+	public fun <init> ()V
+	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
+	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun exclude (Lgroovy/lang/Closure;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun exclude (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun exclude (Lorg/gradle/api/specs/Spec;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun exclude ([Ljava/lang/String;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public fun getExcludes ()Ljava/util/Set;
+	public fun getIncludes ()Ljava/util/Set;
+	public fun include (Lgroovy/lang/Closure;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun include (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun include (Lorg/gradle/api/specs/Spec;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun include ([Ljava/lang/String;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun setExcludes (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public fun setIncludes (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
+}
+
 public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest : org/gradle/api/java/archives/Manifest {
 	public fun inheritFrom ([Ljava/lang/Object;)V
 	public abstract fun inheritFrom ([Ljava/lang/Object;Lorg/gradle/api/Action;)V

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -179,7 +179,6 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/Dependenc
 public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath : org/gradle/api/DefaultTask, org/gradle/api/tasks/util/PatternFilterable {
 	public fun <init> ()V
 	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
-	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun exclude (Lgroovy/lang/Closure;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude (Lorg/gradle/api/specs/Spec;)Lorg/gradle/api/tasks/util/PatternFilterable;

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -183,6 +183,7 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/FindResou
 	public fun exclude (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude (Lorg/gradle/api/specs/Spec;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude ([Ljava/lang/String;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	public final fun findResources ()V
 	protected abstract fun getArchiveOperations ()Lorg/gradle/api/file/ArchiveOperations;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getExcludes ()Ljava/util/Set;

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -184,6 +184,7 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/FindResou
 	public fun exclude (Ljava/lang/Iterable;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude (Lorg/gradle/api/specs/Spec;)Lorg/gradle/api/tasks/util/PatternFilterable;
 	public fun exclude ([Ljava/lang/String;)Lorg/gradle/api/tasks/util/PatternFilterable;
+	protected abstract fun getArchiveOperations ()Lorg/gradle/api/file/ArchiveOperations;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getExcludes ()Ljava/util/Set;
 	public fun getIncludes ()Ljava/util/Set;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -12,6 +12,7 @@
 - Expose `patternSet` of `PreserveFirstFoundResourceTransformer` as `public`. ([#1855](https://github.com/GradleUp/shadow/pull/1855))
 - Support overriding output path of `ApacheNoticeResourceTransformer`. ([#1851](https://github.com/GradleUp/shadow/pull/1851))
 - Add new merge strategy `Fail` to `PropertiesFileTransformer`. ([#1856](https://github.com/GradleUp/shadow/pull/1856))
+- Add convenience `FindResourceInClasspath` task to help debugging issues with merged licenses and duplicated resources. ([#1860](https://github.com/GradleUp/shadow/pull/1860))
 
 ### Changed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -12,7 +12,7 @@
 - Expose `patternSet` of `PreserveFirstFoundResourceTransformer` as `public`. ([#1855](https://github.com/GradleUp/shadow/pull/1855))
 - Support overriding output path of `ApacheNoticeResourceTransformer`. ([#1851](https://github.com/GradleUp/shadow/pull/1851))
 - Add new merge strategy `Fail` to `PropertiesFileTransformer`. ([#1856](https://github.com/GradleUp/shadow/pull/1856))
-- Add convenience `FindResourceInClasspath` task to help debugging issues with merged licenses and duplicated resources. ([#1860](https://github.com/GradleUp/shadow/pull/1860))
+- Add `FindResourceInClasspath` task to help with debugging issues with merged duplicate resources. ([#1860](https://github.com/GradleUp/shadow/pull/1860))
 
 ### Changed
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
@@ -29,8 +30,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
       """.trimIndent(),
     )
 
-    val result1 = runWithSuccess(":find1")
-    assertThat(result1.output).contains(
+    assertThat(runWithSuccess(":find1").output).contains(
       "> Task :find1",
       "scanning ",
       "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
@@ -38,26 +38,28 @@ class FindResourceInClasspathTest : BasePluginTest() {
       "/a2.properties".invariantSeparatorsPathString,
     )
 
-    val result2 = runWithSuccess(":find2")
-    assertThat(result2.output).contains(
-      "> Task :find2",
-      "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a.properties".invariantSeparatorsPathString,
-    )
-    assertThat(result2.output).doesNotContain(
-      "/a2.properties".invariantSeparatorsPathString,
-    )
+    assertThat(runWithSuccess(":find2").output).all {
+      contains(
+        "> Task :find2",
+        "scanning ",
+        "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
+        "/a.properties".invariantSeparatorsPathString,
+      )
+      doesNotContain(
+        "/a2.properties".invariantSeparatorsPathString,
+      )
+    }
 
-    val result3 = runWithSuccess(":find3")
-    assertThat(result3.output).contains(
-      "> Task :find3",
-      "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a2.properties".invariantSeparatorsPathString,
-    )
-    assertThat(result3.output).doesNotContain(
-      "/a.properties".invariantSeparatorsPathString,
-    )
+    assertThat(runWithSuccess(":find3").output).all {
+      contains(
+        "> Task :find3",
+        "scanning ",
+        "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
+        "/a2.properties".invariantSeparatorsPathString,
+      )
+      doesNotContain(
+        "/a.properties".invariantSeparatorsPathString,
+      )
+    }
   }
 }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -4,6 +4,7 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
+import com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath
 import com.github.jengelman.gradle.plugins.shadow.util.variantSeparatorsPathString
 import kotlin.io.path.appendText
 import org.junit.jupiter.api.Test
@@ -11,19 +12,20 @@ import org.junit.jupiter.api.Test
 class FindResourceInClasspathTest : BasePluginTest() {
   @Test
   fun findResourceInClasspath() {
+    val taskClassName = FindResourceInClasspath::class.java.name
     projectScript.appendText(
       """
         dependencies {
           implementation 'my:a:1.0'
         }
-        tasks.register('find1', com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath) {
+        tasks.register('find1', $taskClassName) {
           classpath = configurations.runtimeClasspath
         }
-        tasks.register('find2', com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath) {
+        tasks.register('find2', $taskClassName) {
           classpath = configurations.runtimeClasspath
           include("a.properties")
         }
-        tasks.register('find3', com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath) {
+        tasks.register('find3', $taskClassName) {
           classpath = configurations.runtimeClasspath
           exclude("a.properties")
         }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -3,7 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
-import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
+import com.github.jengelman.gradle.plugins.shadow.util.invariantFilePathString
 import kotlin.io.path.appendText
 import org.junit.jupiter.api.Test
 
@@ -33,7 +33,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result1.output).contains(
       "> Task :find1",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar",
+      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
       "/a.properties",
       "/a2.properties",
     )
@@ -42,7 +42,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result2.output).contains(
       "> Task :find2",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar",
+      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
       "/a.properties",
     )
     assertThat(result2.output).doesNotContain(
@@ -53,7 +53,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result3.output).contains(
       "> Task :find3",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar",
+      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
       "/a2.properties",
     )
     assertThat(result3.output).doesNotContain(

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -3,7 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
-import com.github.jengelman.gradle.plugins.shadow.util.invariantFilePathString
+import com.github.jengelman.gradle.plugins.shadow.util.invariantSeparatorsPathString
 import kotlin.io.path.appendText
 import org.junit.jupiter.api.Test
 
@@ -33,7 +33,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result1.output).contains(
       "> Task :find1",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
+      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
       "/a.properties",
       "/a2.properties",
     )
@@ -42,7 +42,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result2.output).contains(
       "> Task :find2",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
+      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
       "/a.properties",
     )
     assertThat(result2.output).doesNotContain(
@@ -53,7 +53,7 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(result3.output).contains(
       "> Task :find3",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantFilePathString,
+      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
       "/a2.properties",
     )
     assertThat(result3.output).doesNotContain(

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -34,8 +34,8 @@ class FindResourceInClasspathTest : BasePluginTest() {
       "> Task :find1",
       "scanning ",
       "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a.properties",
-      "/a2.properties",
+      "/a.properties".invariantSeparatorsPathString,
+      "/a2.properties".invariantSeparatorsPathString,
     )
 
     val result2 = runWithSuccess(":find2")
@@ -43,10 +43,10 @@ class FindResourceInClasspathTest : BasePluginTest() {
       "> Task :find2",
       "scanning ",
       "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a.properties",
+      "/a.properties".invariantSeparatorsPathString,
     )
     assertThat(result2.output).doesNotContain(
-      "/a2.properties",
+      "/a2.properties".invariantSeparatorsPathString,
     )
 
     val result3 = runWithSuccess(":find3")
@@ -54,10 +54,10 @@ class FindResourceInClasspathTest : BasePluginTest() {
       "> Task :find3",
       "scanning ",
       "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a2.properties",
+      "/a2.properties".invariantSeparatorsPathString,
     )
     assertThat(result3.output).doesNotContain(
-      "/a.properties",
+      "/a.properties".invariantSeparatorsPathString,
     )
   }
 }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -1,0 +1,22 @@
+package com.github.jengelman.gradle.plugins.shadow
+
+import assertk.assertThat
+import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
+import kotlin.io.path.appendText
+import org.junit.jupiter.api.Test
+
+class FindResourceInClasspathTest : BasePluginTest() {
+  @Test
+  fun findResourceInClasspath() {
+    projectScript.appendText(
+      """
+        tasks.register('findResourcesInClasspath', com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath) {
+
+        }
+      """.trimIndent(),
+    )
+
+    val result = runWithSuccess(":findResourcesInClasspath")
+    result.output.lines().forEach { println(it) }
+  }
+}

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/FindResourceInClasspathTest.kt
@@ -4,7 +4,7 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
-import com.github.jengelman.gradle.plugins.shadow.util.invariantSeparatorsPathString
+import com.github.jengelman.gradle.plugins.shadow.util.variantSeparatorsPathString
 import kotlin.io.path.appendText
 import org.junit.jupiter.api.Test
 
@@ -33,20 +33,20 @@ class FindResourceInClasspathTest : BasePluginTest() {
     assertThat(runWithSuccess(":find1").output).contains(
       "> Task :find1",
       "scanning ",
-      "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-      "/a.properties".invariantSeparatorsPathString,
-      "/a2.properties".invariantSeparatorsPathString,
+      "/my/a/1.0/a-1.0.jar".variantSeparatorsPathString,
+      "/a.properties".variantSeparatorsPathString,
+      "/a2.properties".variantSeparatorsPathString,
     )
 
     assertThat(runWithSuccess(":find2").output).all {
       contains(
         "> Task :find2",
         "scanning ",
-        "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-        "/a.properties".invariantSeparatorsPathString,
+        "/my/a/1.0/a-1.0.jar".variantSeparatorsPathString,
+        "/a.properties".variantSeparatorsPathString,
       )
       doesNotContain(
-        "/a2.properties".invariantSeparatorsPathString,
+        "/a2.properties".variantSeparatorsPathString,
       )
     }
 
@@ -54,11 +54,11 @@ class FindResourceInClasspathTest : BasePluginTest() {
       contains(
         "> Task :find3",
         "scanning ",
-        "/my/a/1.0/a-1.0.jar".invariantSeparatorsPathString,
-        "/a2.properties".invariantSeparatorsPathString,
+        "/my/a/1.0/a-1.0.jar".variantSeparatorsPathString,
+        "/a2.properties".variantSeparatorsPathString,
       )
       doesNotContain(
-        "/a.properties".invariantSeparatorsPathString,
+        "/a.properties".variantSeparatorsPathString,
       )
     }
   }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.util
 
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -7,3 +8,5 @@ import kotlin.io.path.writeText
 fun Path.prependText(text: String) = writeText(text + readText())
 
 val String.invariantEolString: String get() = replace(System.lineSeparator(), "\n")
+
+val String.invariantFilePathString: String get() = replace(File.separator, "/")

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
@@ -9,4 +9,4 @@ fun Path.prependText(text: String) = writeText(text + readText())
 
 val String.invariantEolString: String get() = replace(System.lineSeparator(), "\n")
 
-val String.invariantFilePathString: String get() = replace(File.separator, "/")
+val String.invariantSeparatorsPathString: String get() = replace(File.separator, "/")

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.util
 
-import java.io.File
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -9,4 +9,6 @@ fun Path.prependText(text: String) = writeText(text + readText())
 
 val String.invariantEolString: String get() = replace(System.lineSeparator(), "\n")
 
-val String.invariantSeparatorsPathString: String get() = replace(File.separator, "/")
+val String.variantSeparatorsPathString: String get() = replace("/", fileSystem.separator)
+
+private val fileSystem = FileSystems.getDefault()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -4,13 +4,13 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Helper task to temporarily add to your build script to find resources in the classpath that were
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.util.PatternSet
  * }
  * ```
  */
+@DisableCachingByDefault(because = "Not worth caching")
 public abstract class FindResourceInClasspath(private val patternSet: PatternSet) :
   DefaultTask(),
   PatternFilterable by patternSet {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -1,6 +1,8 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -50,12 +52,15 @@ public abstract class FindResourceInClasspath(private val patternSet: PatternSet
   @Input
   override fun getExcludes(): MutableSet<String> = patternSet.excludes
 
+  @get:Inject
+  protected abstract val archiveOperations: ArchiveOperations
+
   @TaskAction
   internal fun findResources() {
     classpath.forEach { file ->
       logger.lifecycle("scanning {}", file)
 
-      project.zipTree(file).matching(patternSet).forEach { entry ->
+      archiveOperations.zipTree(file).matching(patternSet).forEach { entry ->
         logger.lifecycle("  -> {}", entry)
       }
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -59,7 +59,7 @@ public abstract class FindResourceInClasspath(private val patternSet: PatternSet
   protected abstract val archiveOperations: ArchiveOperations
 
   @TaskAction
-  internal fun findResources() {
+  public fun findResources() {
     classpath.forEach { file ->
       logger.lifecycle("scanning {}", file)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -1,0 +1,63 @@
+package com.github.jengelman.gradle.plugins.shadow.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.util.PatternFilterable
+import org.gradle.api.tasks.util.PatternSet
+
+/**
+ * Helper task to temporarily add to your build script to find resources in the classpath that were
+ * identified as duplicates by [com.github.jengelman.gradle.plugins.shadow.transformers.MergePropertiesResourceTransformer] or
+ * [com.github.jengelman.gradle.plugins.shadow.transformers.DeduplicatingResourceTransformer].
+ *
+ * First, add the task to your build script:
+ * ```kotlin
+ * val findResources by tasks.registering(FindResourceInClasspath::class) {
+ *   // add configurations to search for resources in dependency jars
+ *   classpath.from(configurations.runtimeClasspath)
+ *   // the patterns to search for (it is a Gradle PatternFilterable)
+ *   include(
+ *     "META-INF/...",
+ *   )
+ * }
+ * ```
+ *
+ * Then let `shadowJar` depend on the task, or just run the above task manually.
+ *
+ * ```kotlin
+ * tasks.named("shadowJar") {
+ *   dependsOn(findResources)
+ * }
+ * ```
+ */
+@Suppress("unused")
+@CacheableTask
+public abstract class FindResourceInClasspath(private val patternSet: PatternSet = PatternSet()) :
+  DefaultTask(),
+  PatternFilterable by patternSet {
+  @get:InputFiles
+  @get:Classpath
+  public abstract val classpath: ConfigurableFileCollection
+
+  @Input
+  override fun getIncludes(): MutableSet<String> = patternSet.includes
+
+  @Input
+  override fun getExcludes(): MutableSet<String> = patternSet.excludes
+
+  @TaskAction
+  internal fun findResources() {
+    classpath.forEach { file ->
+      logger.lifecycle("scanning {}", file)
+
+      project.zipTree(file).matching(patternSet).forEach { entry ->
+        logger.lifecycle("  -> {}", entry)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -39,9 +39,12 @@ import org.gradle.api.tasks.util.PatternSet
  */
 @Suppress("unused")
 @CacheableTask
-public abstract class FindResourceInClasspath(private val patternSet: PatternSet = PatternSet()) :
+public abstract class FindResourceInClasspath(private val patternSet: PatternSet) :
   DefaultTask(),
   PatternFilterable by patternSet {
+
+  @Inject public constructor() : this(PatternSet())
+
   @get:InputFiles
   @get:Classpath
   public abstract val classpath: ConfigurableFileCollection

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -49,10 +49,10 @@ public abstract class FindResourceInClasspath(private val patternSet: PatternSet
   @get:Classpath
   public abstract val classpath: ConfigurableFileCollection
 
-  @Input
+  @Input // Trigger task executions after includes changed.
   override fun getIncludes(): MutableSet<String> = patternSet.includes
 
-  @Input
+  @Input // Trigger task executions after excludes changed.
   override fun getExcludes(): MutableSet<String> = patternSet.excludes
 
   @get:Inject

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.util.PatternSet
  * [com.github.jengelman.gradle.plugins.shadow.transformers.DeduplicatingResourceTransformer].
  *
  * First, add the task to your build script:
+ *
  * ```kotlin
  * val findResources by tasks.registering(FindResourceInClasspath::class) {
  *   // add configurations to search for resources in dependency jars
@@ -32,12 +33,11 @@ import org.gradle.api.tasks.util.PatternSet
  * Then let `shadowJar` depend on the task, or just run the above task manually.
  *
  * ```kotlin
- * tasks.named("shadowJar") {
+ * tasks.shadowJar {
  *   dependsOn(findResources)
  * }
  * ```
  */
-@Suppress("unused")
 @CacheableTask
 public abstract class FindResourceInClasspath(private val patternSet: PatternSet) :
   DefaultTask(),

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/FindResourceInClasspath.kt
@@ -38,7 +38,6 @@ import org.gradle.api.tasks.util.PatternSet
  * }
  * ```
  */
-@CacheableTask
 public abstract class FindResourceInClasspath(private val patternSet: PatternSet) :
   DefaultTask(),
   PatternFilterable by patternSet {


### PR DESCRIPTION
aka: "which dependencies contain the path XYZ"

Refs #1848.

---

- [X] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
