### PR TITLE
Add `invariantEolString` for `String`

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer.MergeStrategy
 import com.github.jengelman.gradle.plugins.shadow.util.Issue
+import com.github.jengelman.gradle.plugins.shadow.util.invariantEolString
 import kotlin.io.path.appendText
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.junit.jupiter.api.Assertions.fail
@@ -39,7 +40,7 @@ class PropertiesFileTransformerTest : BaseTransformerTest() {
       val result = runWithFailure(shadowJarPath)
 
       assertThat(result).taskOutcomeEquals(shadowJarPath, FAILED)
-      assertThat(result.output.replace(lineSeparator, "\n")).contains(
+      assertThat(result.output.invariantEolString).contains(
         """
           Caused by: java.lang.IllegalStateException: The following properties files have conflicting property values and cannot be merged:
            * META-INF/test.properties

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/util/Paths.kt
@@ -5,3 +5,5 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 fun Path.prependText(text: String) = writeText(text + readText())
+
+val String.invariantEolString: String get() = replace(System.lineSeparator(), "\n")


### PR DESCRIPTION
Refs https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.io.path/invariant-separators-path-string.html

