### PR TITLE
GH workflows: Move from zulu to temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version-file: .github/workflows/.java-version
       - uses: gradle/actions/setup-gradle@v5
       - run: ./gradlew build "-PtestGradleVersion=${{ matrix.gradle }}" --stacktrace
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version-file: .github/workflows/.java-version
       - uses: gradle/actions/setup-gradle@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version-file: .github/workflows/.java-version
       - uses: gradle/actions/setup-gradle@v5
         with:


### PR DESCRIPTION
... to workaround recent CI failures. Not sure those will persist.

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
