### PR TITLE
Deprecate `ShadowCopyAction`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -22,6 +22,8 @@
 - Bump min Gradle requirement to 9.0.0. ([#1801](https://github.com/GradleUp/shadow/pull/1801))
 - Deprecate `PreserveFirstFoundResourceTransformer.resources`. ([#1855](https://github.com/GradleUp/shadow/pull/1855))
 - Make the output of `PropertiesFileTransformer` reproducible. ([#1861](https://github.com/GradleUp/shadow/pull/1861))
+- Deprecate `ShadowCopyAction`. ([#1876](https://github.com/GradleUp/shadow/pull/1876))  
+  It should not be used as a public API. Will be made internal in a future release.
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -37,7 +37,9 @@ import org.objectweb.asm.commons.ClassRemapper
 /**
  * Modified from [org.gradle.api.internal.file.archive.ZipCopyAction.java](https://github.com/gradle/gradle/blob/b893c2b085046677cf858fb3d5ce00e68e556c3a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java).
  */
-public open class ShadowCopyAction(
+public open class ShadowCopyAction
+@Deprecated("This should not be used as a public API. Will be made internal in a future release.")
+constructor(
   private val zipFile: File,
   private val zosProvider: (File) -> ZipOutputStream,
   private val transformers: Set<ResourceTransformer>,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -425,6 +425,7 @@ public abstract class ShadowJar : Jar() {
     } else {
       emptySet()
     }
+    @Suppress("DEPRECATION")
     return ShadowCopyAction(
       zipFile = archiveFile.get().asFile,
       zosProvider = zosProvider,


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
