### PR TITLE
Simplify checks for Zip64RequiredException

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -67,11 +67,11 @@ constructor(
         checkDuplicateEntries(zos)
       }
     } catch (e: Exception) {
-      if (e is Zip64RequiredException || e.cause is Zip64RequiredException) {
-        val message = if (e is Zip64RequiredException) e.message else e.cause?.message
+      val cause = e.cause
+      if (cause is Zip64RequiredException) {
         throw Zip64RequiredException(
           """
-            $message
+            ${cause.message}
 
             To build this archive, please enable the zip64 extension. e.g.
             ```kts


### PR DESCRIPTION
Refs https://github.com/gradle/gradle/blob/1468e41e448ec0c31f6f5b6999825da00e22c931/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L67.

---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
