### PR TITLE
Remove parallel flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
-org.gradle.parallel=true
 org.gradle.tooling.parallel=true
 
 ########## Properties for publishing to Maven Central ##########

--- a/src/testKit/kotlin/com/github/jengelman/gradle/plugins/shadow/testkit/GradleRunner.kt
+++ b/src/testKit/kotlin/com/github/jengelman/gradle/plugins/shadow/testkit/GradleRunner.kt
@@ -24,7 +24,6 @@ val commonGradleArgs =
   setOf(
     "--configuration-cache",
     "--build-cache",
-    "--parallel",
     "--stacktrace",
     // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:parallel
     "-Dorg.gradle.configuration-cache.parallel=true",


### PR DESCRIPTION
It should be retired.

Per https://github.com/gradle/gradle/issues/37763.
