### PR TITLE
Update jdependency to support Java 27

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
   implementation("org.codehaus.plexus:plexus-utils:4.0.2")
   implementation("org.codehaus.plexus:plexus-xml:4.1.1")
   implementation("org.apache.logging.log4j:log4j-core:2.25.3")
-  implementation("org.vafer:jdependency:2.15")
+  implementation("org.vafer:jdependency:2.16")
 
   testImplementation("org.spockframework:spock-core:2.4-groovy-4.0") {
     exclude(group = "org.codehaus.groovy")

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+**Changed**
+
+- Update jdependency to support Java 27. ([#2033](https://github.com/GradleUp/shadow/pull/2033))
+
 **Deprecated**
 
 - Deprecate `KnowsTask`, it will be removed in the next major release. ([#1957](https://github.com/GradleUp/shadow/pull/1957))

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 **Changed**
 
-- Update jdependency to support Java 27. ([#2033](https://github.com/GradleUp/shadow/pull/2033))
+- Update jdependency to support Java 27. ([#2040](https://github.com/GradleUp/shadow/pull/2040))
 
 **Deprecated**
 


### PR DESCRIPTION
Ports #2033.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
