### PR TITLE
Remove `afterEvaluate` when adding variants

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Bump min Gradle requirement to 9.1.0. ([#2016](https://github.com/GradleUp/shadow/pull/2016))
+- Remove `afterEvaluate` when adding variants. ([#2056](https://github.com/GradleUp/shadow/pull/2056))
 
 ## [9.4.2](https://github.com/GradleUp/shadow/releases/tag/9.4.2) - 2026-05-28
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -129,18 +129,14 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     shadowComponent.addVariantsFromConfigurationCompat(shadowRuntimeElements) { variant ->
       variant.mapToMavenScope("runtime")
     }
-    // Must use afterEvaluate here as we need to track the changes of
-    // addShadowVariantIntoJavaComponent.
-    afterEvaluate {
-      if (shadow.addShadowVariantIntoJavaComponent.get()) {
-        logger.info("Adding {} variant to Java component.", shadowRuntimeElements.name)
-      } else {
-        logger.info("Skipping adding {} variant to Java component.", shadowRuntimeElements.name)
-        return@afterEvaluate
-      }
-      components.named("java", AdhocComponentWithVariants::class.java) {
-        it.addVariantsFromConfigurationCompat(shadowRuntimeElements) { variant ->
-          variant.mapToOptional()
+    components.named("java", AdhocComponentWithVariants::class.java) { component ->
+      component.addVariantsFromConfigurationCompat(shadowRuntimeElements) { variant ->
+        variant.mapToOptional()
+        if (shadow.addShadowVariantIntoJavaComponent.get()) {
+          logger.info("Adding {} variant to Java component.", shadowRuntimeElements.name)
+        } else {
+          logger.info("Skipping adding {} variant to Java component.", shadowRuntimeElements.name)
+          variant.skip()
         }
       }
     }


### PR DESCRIPTION
Follow up https://github.com/GradleUp/shadow/pull/1662#discussion_r3449635819.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
