### PR TITLE
Revert "Make most transformers pattern-filterable (#2028)"

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -320,12 +320,10 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Appen
 public abstract interface annotation class com/github/jengelman/gradle/plugins/shadow/transformers/CacheableTransformer : java/lang/annotation/Annotation {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field COMPONENTS_XML_PATH Ljava/lang/String;
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer$Companion;
 	public fun <init> ()V
-	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
-	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun hasTransformedResource ()Z
 	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
@@ -355,7 +353,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/DontInclude
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer$Companion;
 	public static final field KEY_EXTENSION_CLASSES Ljava/lang/String;
 	public static final field KEY_MODULE_NAME Ljava/lang/String;
@@ -366,8 +364,6 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExten
 	public static final field PATH_GROOVY_EXTENSION_MODULE_DESCRIPTOR Ljava/lang/String;
 	public static final field PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
-	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun hasTransformedResource ()Z
 	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
@@ -389,19 +385,16 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeReso
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> ()V
-	public fun <init> (Lorg/gradle/api/tasks/util/PatternSet;)V
-	public synthetic fun <init> (Lorg/gradle/api/tasks/util/PatternSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun hasTransformedResource ()Z
 	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
-	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun append (Ljava/lang/String;Ljava/lang/Comparable;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getAttributes ()Lorg/gradle/api/provider/SetProperty;
@@ -411,9 +404,8 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestApp
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
-	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun attributes (Ljava/util/Map;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getMainClass ()Lorg/gradle/api/provider/Property;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,11 +7,6 @@
 
 - Check `DuplicatesStrategy` for merging transformers. ([#2026](https://github.com/GradleUp/shadow/pull/2026))  
   This will log warnings when an incompatible `DuplicatesStrategy` (e.g., `EXCLUDE`) is applied in Gradle configuration for built-in `ResourceTransformer`s.
-- Expose `patternSet` of `ComponentsXmlResourceTransformer` as `public`. ([#2028](https://github.com/GradleUp/shadow/pull/2028))
-- Expose `patternSet` of `GroovyExtensionModuleTransformer` as `public`. ([#2028](https://github.com/GradleUp/shadow/pull/2028))
-- Expose `patternSet` of `Log4j2PluginsCacheFileTransformer` as `public`. ([#2028](https://github.com/GradleUp/shadow/pull/2028))
-- Expose `patternSet` of `ManifestAppenderTransformer` as `public`. ([#2028](https://github.com/GradleUp/shadow/pull/2028))
-- Expose `patternSet` of `ManifestResourceTransformer` as `public`. ([#2028](https://github.com/GradleUp/shadow/pull/2028))
 
 ### Changed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
@@ -14,7 +14,6 @@ import org.codehaus.plexus.util.xml.Xpp3DomBuilder
 import org.codehaus.plexus.util.xml.Xpp3DomWriter
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * A resource processor that aggregates plexus `components.xml` files.
@@ -25,10 +24,7 @@ import org.gradle.api.tasks.util.PatternSet
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ComponentsXmlResourceTransformer
-@JvmOverloads
-constructor(patternSet: PatternSet = PatternSet().include(COMPONENTS_XML_PATH)) :
-  PatternFilterableResourceTransformer(patternSet) {
+public open class ComponentsXmlResourceTransformer : ResourceTransformer {
   private val components = mutableMapOf<String, Xpp3Dom>()
 
   @get:Internal
@@ -48,7 +44,7 @@ constructor(patternSet: PatternSet = PatternSet().include(COMPONENTS_XML_PATH)) 
     }
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return super.canTransformResource(element).also { flag -> checkDupStrategy(flag, element) }
+    return (COMPONENTS_XML_PATH == element.path).also { flag -> checkDupStrategy(flag, element) }
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
@@ -7,7 +7,6 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.relocateClass
 import java.util.Properties
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * Aggregate Apache Groovy extension modules descriptors.
@@ -29,20 +28,16 @@ import org.gradle.api.tasks.util.PatternSet
  * [org.apache.maven.plugins.shade.resource.GroovyResourceTransformer.java](https://github.com/apache/maven-shade-plugin/blob/master/src/main/java/org/apache/maven/plugins/shade/resource/GroovyResourceTransformer.java).
  */
 @CacheableTransformer
-public open class GroovyExtensionModuleTransformer
-@JvmOverloads
-constructor(
-  patternSet: PatternSet =
-    PatternSet()
-      .include(
-        PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR,
-        PATH_GROOVY_EXTENSION_MODULE_DESCRIPTOR,
-      )
-) : PatternFilterableResourceTransformer(patternSet) {
+public open class GroovyExtensionModuleTransformer : ResourceTransformer {
   private val module = Properties()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return super.canTransformResource(element).also { flag -> checkDupStrategy(flag, element) }
+    return element.path
+      .let { path ->
+        path == PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR ||
+          path == PATH_GROOVY_EXTENSION_MODULE_DESCRIPTOR
+      }
+      .also { flag -> checkDupStrategy(flag, element) }
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2PluginsCacheFileTransformer.kt
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
 import org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE
 import org.apache.tools.zip.ZipOutputStream
 import org.gradle.api.file.FileTreeElement
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * Modified from
@@ -26,10 +25,7 @@ import org.gradle.api.tasks.util.PatternSet
  * @author John Engelman
  */
 @CacheableTransformer
-public open class Log4j2PluginsCacheFileTransformer
-@JvmOverloads
-constructor(patternSet: PatternSet = PatternSet().include(PLUGIN_CACHE_FILE)) :
-  PatternFilterableResourceTransformer(patternSet) {
+public open class Log4j2PluginsCacheFileTransformer : ResourceTransformer {
   /** Log4j config files to share across the transformation stages. */
   private val tempFiles = mutableListOf<Path>()
 
@@ -37,7 +33,7 @@ constructor(patternSet: PatternSet = PatternSet().include(PLUGIN_CACHE_FILE)) :
   private val tempRelocators = mutableListOf<Relocator>()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return super.canTransformResource(element).also { flag -> checkDupStrategy(flag, element) }
+    return (PLUGIN_CACHE_FILE == element.path).also { flag -> checkDupStrategy(flag, element) }
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -13,7 +13,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * A resource processor that can append arbitrary attributes to the first MANIFEST.MF that is found
@@ -25,25 +24,18 @@ import org.gradle.api.tasks.util.PatternSet
  * @author Chris Rankin
  */
 @CacheableTransformer
-public open class ManifestAppenderTransformer(
-  final override val objectFactory: ObjectFactory,
-  patternSet: PatternSet,
-) : PatternFilterableResourceTransformer(patternSet) {
+public open class ManifestAppenderTransformer
+@Inject
+constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var manifestContents = ByteArray(0)
 
   @get:Input
   public open val attributes: SetProperty<Pair<String, Comparable<*>>> = objectFactory.setProperty()
 
-  @Inject
-  public constructor(
-    objectFactory: ObjectFactory
-  ) : this(
-    objectFactory,
-    patternSet = PatternSet().apply { isCaseSensitive = false }.include(MANIFEST_NAME),
-  )
-
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return super.canTransformResource(element).also { flag -> checkDupStrategy(flag, element) }
+    return MANIFEST_NAME.equals(element.path, ignoreCase = true).also { flag ->
+      checkDupStrategy(flag, element)
+    }
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -7,7 +7,7 @@ import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.zipEntry
 import java.io.IOException
 import java.util.jar.Attributes as JarAttribute
-import java.util.jar.JarFile
+import java.util.jar.JarFile.MANIFEST_NAME
 import java.util.jar.Manifest
 import javax.inject.Inject
 import org.apache.tools.zip.ZipOutputStream
@@ -17,7 +17,6 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.util.PatternSet
 
 /**
  * A resource processor that allows the arbitrary addition of attributes to the first MANIFEST.MF
@@ -31,10 +30,9 @@ import org.gradle.api.tasks.util.PatternSet
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ManifestResourceTransformer(
-  final override val objectFactory: ObjectFactory,
-  patternSet: PatternSet,
-) : PatternFilterableResourceTransformer(patternSet) {
+public open class ManifestResourceTransformer
+@Inject
+constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var manifestDiscovered = false
   private var manifest: Manifest? = null
 
@@ -43,16 +41,10 @@ public open class ManifestResourceTransformer(
   @get:Input
   public open val manifestEntries: MapProperty<String, JarAttribute> = objectFactory.mapProperty()
 
-  @Inject
-  public constructor(
-    objectFactory: ObjectFactory
-  ) : this(
-    objectFactory,
-    patternSet = PatternSet().apply { isCaseSensitive = false }.include(JarFile.MANIFEST_NAME),
-  )
-
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    return super.canTransformResource(element).also { flag -> checkDupStrategy(flag, element) }
+    return MANIFEST_NAME.equals(element.path, ignoreCase = true).also { flag ->
+      checkDupStrategy(flag, element)
+    }
   }
 
   override fun transform(context: TransformerContext) {
@@ -83,7 +75,7 @@ public open class ManifestResourceTransformer(
     mainClass.get().takeIf(CharSequence::isNotEmpty)?.let { attributes[mainClassAttributeKey] = it }
     manifestEntries.get().forEach { (key, value) -> attributes[JarAttribute.Name(key)] = value }
 
-    os.putNextEntry(zipEntry(JarFile.MANIFEST_NAME, preserveFileTimestamps))
+    os.putNextEntry(zipEntry(MANIFEST_NAME, preserveFileTimestamps))
     manifest!!.write(os)
     os.closeEntry()
   }


### PR DESCRIPTION
We don't have to expose so many `PatternSet`s for these transformers for now.

Reverts #2028.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
