### PR TITLE
Deprecate everything under `ShadowCopyAction`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -238,6 +238,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAc
 }
 
 public abstract class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar : org/gradle/api/tasks/bundling/Jar {
+	public static final field CONSTANT_TIME_FOR_ZIP_ENTRIES J
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar$Companion;
 	public static final field SHADOW_JAR_TASK_NAME Ljava/lang/String;
 	public fun <init> ()V

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -228,7 +228,6 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 }
 
 public class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction : org/gradle/api/internal/file/copy/CopyAction {
-	public static final field CONSTANT_TIME_FOR_ZIP_ENTRIES J
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction$Companion;
 	public fun <init> (Ljava/io/File;Lkotlin/jvm/functions/Function1;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ZZZLjava/lang/String;)V
 	public fun execute (Lorg/gradle/api/internal/file/copy/CopyActionProcessingStream;)Lorg/gradle/api/tasks/WorkResult;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -16,6 +16,7 @@
 - Remove `afterEvaluate` when adding variants. ([#2056](https://github.com/GradleUp/shadow/pull/2056))
 - Deprecate `enableKotlinModuleRemapping` for `ShadowJar`. ([#2073](https://github.com/GradleUp/shadow/pull/2073))  
   Apply `KotlinModuleMetadataTransformer` explicitly to support relocating inside Kotlin module metadata files.
+- Deprecate the whole things under `ShadowCopyAction`. ([#2083](https://github.com/GradleUp/shadow/pull/2083))
 
 ### Fixed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -16,7 +16,7 @@
 - Remove `afterEvaluate` when adding variants. ([#2056](https://github.com/GradleUp/shadow/pull/2056))
 - Deprecate `enableKotlinModuleRemapping` for `ShadowJar`. ([#2073](https://github.com/GradleUp/shadow/pull/2073))  
   Apply `KotlinModuleMetadataTransformer` explicitly to support relocating inside Kotlin module metadata files.
-- Deprecate the whole things under `ShadowCopyAction`. ([#2083](https://github.com/GradleUp/shadow/pull/2083))
+- Deprecate everything under `ShadowCopyAction`. ([#2083](https://github.com/GradleUp/shadow/pull/2083))
 
 ### Fixed
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
@@ -10,7 +10,7 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotEqualTo
 import assertk.fail
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction.Companion.CONSTANT_TIME_FOR_ZIP_ENTRIES
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.CONSTANT_TIME_FOR_ZIP_ENTRIES
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
 import com.github.jengelman.gradle.plugins.shadow.testkit.getBytes
 import com.github.jengelman.gradle.plugins.shadow.testkit.requireResourceAsPath

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/Utils.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/Utils.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.internal
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.CONSTANT_TIME_FOR_ZIP_ENTRIES
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
@@ -39,7 +39,7 @@ internal inline fun zipEntry(
         time = lastModified
       }
     } else {
-      time = ShadowCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+      time = CONSTANT_TIME_FOR_ZIP_ENTRIES
     }
     block()
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -226,12 +226,6 @@ public open class ShadowCopyAction(
       get() =
         this::class.java.getDeclaredField("entries").apply { isAccessible = true }.get(this).cast()
 
-    /**
-     * A copy of
-     * [org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES].
-     *
-     * 1980-02-01 00:00:00 (318182400000).
-     */
     @Deprecated(
       message =
         "Use `ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES` const instead. This will be removed in Shadow 10.",

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -228,7 +228,7 @@ public open class ShadowCopyAction(
 
     @Deprecated(
       message =
-        "Use `ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES` const instead. This will be removed in Shadow 10.",
+        "Use `ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES` constant instead. This will be removed in Shadow 10.",
       replaceWith = ReplaceWith("ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES"),
     )
     public val CONSTANT_TIME_FOR_ZIP_ENTRIES: Long = ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -227,21 +227,12 @@ public open class ShadowCopyAction(
       get() =
         this::class.java.getDeclaredField("entries").apply { isAccessible = true }.get(this).cast()
 
-    @Deprecated(
-      message =
-        "Use `CONSTANT_TIME_FOR_ZIP_ENTRIES` const instead. This will be removed in Shadow 10.",
-      replaceWith = ReplaceWith("CONSTANT_TIME_FOR_ZIP_ENTRIES"),
-    )
-    @Suppress("FunctionName") // For ABI compatibility.
-    public fun getCONSTANT_TIME_FOR_ZIP_ENTRIES(): Long = CONSTANT_TIME_FOR_ZIP_ENTRIES
-
     /**
      * A copy of
      * [org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES].
      *
      * 1980-02-01 00:00:00 (318182400000).
      */
-    @JvmField
     public val CONSTANT_TIME_FOR_ZIP_ENTRIES: Long =
       GregorianCalendar(1980, 1, 1, 0, 0, 0).timeInMillis
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -12,7 +12,6 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.relocatePath
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import java.io.File
-import java.util.GregorianCalendar
 import org.apache.tools.zip.UnixStat
 import org.apache.tools.zip.Zip64RequiredException
 import org.apache.tools.zip.ZipEntry
@@ -233,7 +232,11 @@ public open class ShadowCopyAction(
      *
      * 1980-02-01 00:00:00 (318182400000).
      */
-    public val CONSTANT_TIME_FOR_ZIP_ENTRIES: Long =
-      GregorianCalendar(1980, 1, 1, 0, 0, 0).timeInMillis
+    @Deprecated(
+      message =
+        "Use `ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES` const instead. This will be removed in Shadow 10.",
+      replaceWith = ReplaceWith("ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES"),
+    )
+    public val CONSTANT_TIME_FOR_ZIP_ENTRIES: Long = ShadowJar.CONSTANT_TIME_FOR_ZIP_ENTRIES
   }
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -31,11 +31,8 @@ import org.gradle.api.tasks.WorkResults
  * Modified from
  * [org.gradle.api.internal.file.archive.ZipCopyAction.java](https://github.com/gradle/gradle/blob/b893c2b085046677cf858fb3d5ce00e68e556c3a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java).
  */
-public open class ShadowCopyAction
-@Deprecated(
-  "This constructor should not be used as a public API. Will be made internal in Shadow 10."
-)
-constructor(
+@Deprecated("This should not be used as a public API. Will be made internal in Shadow 10.")
+public open class ShadowCopyAction(
   private val zipFile: File,
   private val zosProvider: (File) -> ZipOutputStream,
   private val transformers: Set<ResourceTransformer>,
@@ -223,7 +220,7 @@ constructor(
   }
 
   public companion object {
-    private val logger = Logging.getLogger(ShadowCopyAction::class.java)
+    @Suppress("DEPRECATION") private val logger = Logging.getLogger(ShadowCopyAction::class.java)
     private val multiReleaseRegex = "^META-INF/versions/\\d+/".toRegex()
 
     private val ZipOutputStream.entries: List<ZipEntry>

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -30,6 +30,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransform
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import java.io.File
 import java.io.IOException
+import java.util.GregorianCalendar
 import java.util.jar.JarFile
 import java.util.zip.ZipException
 import java.util.zip.ZipFile
@@ -712,6 +713,16 @@ public abstract class ShadowJar : Jar() {
 
   public companion object {
     public const val SHADOW_JAR_TASK_NAME: String = "shadowJar"
+
+    /**
+     * A copy of
+     * [org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES].
+     *
+     * 1980-02-01 00:00:00 (318182400000).
+     */
+    @JvmField
+    public val CONSTANT_TIME_FOR_ZIP_ENTRIES: Long =
+      GregorianCalendar(1980, 1, 1, 0, 0, 0).timeInMillis
 
     @get:JvmSynthetic
     public inline val TaskContainer.shadowJar: TaskProvider<ShadowJar>


### PR DESCRIPTION
---

- [ ] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
