### PR TITLE
Fix eager calls for `toolchainSpec` in Kotlin DSL

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.5.0...HEAD) - 2026-xx-xx
 
+### Fixed
+
+- Fix eager calls for `targetCompatibility` for `toolchainSpec`.  
+  This fixes the regression when using `toolchain` without `targetCompatibility` in `java` blocks.
 
 ## [9.5.0](https://github.com/GradleUp/shadow/releases/tag/9.5.0) - 2026-07-06
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- Fix eager calls for `targetCompatibility` for `toolchainSpec`.  
+- Fix eager calls for `toolchainSpec` in Kotlin DSL.  
   This fixes the regression when using `toolchain` without `targetCompatibility` in Kotlin DSL.
 
 ## [9.5.0](https://github.com/GradleUp/shadow/releases/tag/9.5.0) - 2026-07-06

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -6,7 +6,7 @@
 ### Fixed
 
 - Fix eager calls for `targetCompatibility` for `toolchainSpec`.  
-  This fixes the regression when using `toolchain` without `targetCompatibility` in `java` blocks.
+  This fixes the regression when using `toolchain` without `targetCompatibility` in Kotlin DSL.
 
 ## [9.5.0](https://github.com/GradleUp/shadow/releases/tag/9.5.0) - 2026-07-06
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -34,7 +34,6 @@ import kotlin.io.path.outputStream
 import kotlin.io.path.writeText
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.javaMethod
-import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
@@ -1223,23 +1222,6 @@ class JavaPluginsTest : BasePluginTest() {
     assertThat(jarPath("app/build/libs/app-all.jar")).useAll {
       containsAtLeast("com/company/Main.class", "com/company/Utils.class", manifestEntry)
     }
-  }
-
-  @Issue("https://github.com/GradleUp/shadow/issues/2086")
-  @Test
-  fun useToolchainWithoutTargetCompatibility() {
-    projectScript.appendText(
-      """
-        java {
-          toolchain.languageVersion = JavaLanguageVersion.of(${JavaVersion.current().majorVersion})
-        }
-      """
-        .trimIndent()
-    )
-
-    val result = runWithSuccess(shadowJarPath)
-
-    assertThat(result.task(shadowJarPath)).isNotNull().transform { it.outcome }.isEqualTo(SUCCESS)
   }
 
   private fun dependencies(configuration: String, vararg flags: String): String {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -28,12 +28,14 @@ import com.github.jengelman.gradle.plugins.shadow.util.Issue
 import com.github.jengelman.gradle.plugins.shadow.util.prependText
 import com.github.jengelman.gradle.plugins.shadow.util.runProcess
 import kotlin.io.path.appendText
+import kotlin.io.path.deleteExisting
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.name
 import kotlin.io.path.outputStream
 import kotlin.io.path.writeText
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.javaMethod
+import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
@@ -1222,6 +1224,29 @@ class JavaPluginsTest : BasePluginTest() {
     assertThat(jarPath("app/build/libs/app-all.jar")).useAll {
       containsAtLeast("com/company/Main.class", "com/company/Utils.class", manifestEntry)
     }
+  }
+
+  @Issue("https://github.com/GradleUp/shadow/issues/2086")
+  @Test
+  fun useToolchainWithoutTargetCompatibilityInKts() {
+    projectScript.deleteExisting()
+    path("build.gradle.kts")
+      .appendText(
+        """
+        plugins {
+          kotlin("jvm")
+          id("$shadowPluginId")
+        }
+        java {
+          toolchain.languageVersion = JavaLanguageVersion.of(${JavaVersion.current().majorVersion})
+        }
+      """
+          .trimIndent()
+      )
+
+    val result = runWithSuccess(shadowJarPath)
+
+    assertThat(result.task(shadowJarPath)).isNotNull().transform { it.outcome }.isEqualTo(SUCCESS)
   }
 
   private fun dependencies(configuration: String, vararg flags: String): String {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -34,6 +34,7 @@ import kotlin.io.path.outputStream
 import kotlin.io.path.writeText
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.javaMethod
+import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
@@ -1222,6 +1223,23 @@ class JavaPluginsTest : BasePluginTest() {
     assertThat(jarPath("app/build/libs/app-all.jar")).useAll {
       containsAtLeast("com/company/Main.class", "com/company/Utils.class", manifestEntry)
     }
+  }
+
+  @Issue("https://github.com/GradleUp/shadow/issues/2086")
+  @Test
+  fun useToolchainWithoutTargetCompatibility() {
+    projectScript.appendText(
+      """
+        java {
+          toolchain.languageVersion = JavaLanguageVersion.of(${JavaVersion.current().majorVersion})
+        }
+      """
+        .trimIndent()
+    )
+
+    val result = runWithSuccess(shadowJarPath)
+
+    assertThat(result.task(shadowJarPath)).isNotNull().transform { it.outcome }.isEqualTo(SUCCESS)
   }
 
   private fun dependencies(configuration: String, vararg flags: String): String {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -54,58 +54,62 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       configurations.named(COMPILE_CLASSPATH_CONFIGURATION_NAME) { compileClasspath ->
         compileClasspath.extendsFromCompat(shadowConfig)
       }
-    configurations.register(SHADOW_RUNTIME_ELEMENTS_CONFIGURATION_NAME) { shadowRuntimeElements ->
-      shadowRuntimeElements.extendsFromCompat(shadowConfig)
-      shadowRuntimeElements.isCanBeConsumed = true
-      shadowRuntimeElements.isCanBeResolved = false
-      shadowRuntimeElements.attributes { attrs ->
-        attrs.attribute(
-          Usage.USAGE_ATTRIBUTE,
-          objects.named(Usage::class.java, Usage.JAVA_RUNTIME),
-        )
-        attrs.attribute(
-          Category.CATEGORY_ATTRIBUTE,
-          objects.named(Category::class.java, Category.LIBRARY),
-        )
-        attrs.attribute(
-          LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-          objects.named(LibraryElements::class.java, LibraryElements.JAR),
-        )
-        attrs.attributeProvider(
-          Bundling.BUNDLING_ATTRIBUTE,
-          shadow.bundlingAttribute.map { attr -> objects.named(Bundling::class.java, attr) },
-        )
-
-        // `targetCompatibility` eagerly calls toolchainSpec, we need to defer it by afterEvaluate.
-        // https://github.com/gradle/gradle/blob/9e1a582adeb5ba12e6ad3807e62964806ea51bbb/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java#L119
-        afterEvaluate {
-          if (shadow.addTargetJvmVersionAttribute.get()) {
-            val compileJvmVersion =
-              compileClasspathConfig.get().attributes.getAttribute(TARGET_JVM_VERSION_ATTRIBUTE)
-            val targetJvmVersion =
-              compileJvmVersion ?: javaPluginExtension.targetCompatibility.majorVersion.toInt()
-            if (targetJvmVersion != Int.MAX_VALUE) {
-              logger.info(
-                "Setting target JVM version to {} for {} configuration.",
-                targetJvmVersion,
-                shadowRuntimeElements.name,
-              )
-              attrs.attribute(TARGET_JVM_VERSION_ATTRIBUTE, targetJvmVersion)
-            } else {
-              logger.info(
-                "Cannot set the target JVM version to Int.MAX_VALUE when `java.autoTargetJvmDisabled` is enabled or in other cases."
-              )
-            }
-          } else {
-            logger.info(
-              "Skipping setting {} attribute for {} configuration.",
-              TARGET_JVM_VERSION_ATTRIBUTE,
-              shadowRuntimeElements.name,
-            )
-          }
+    val shadowRuntimeElements =
+      configurations.register(SHADOW_RUNTIME_ELEMENTS_CONFIGURATION_NAME) { shadowRuntimeElements ->
+        shadowRuntimeElements.extendsFromCompat(shadowConfig)
+        shadowRuntimeElements.isCanBeConsumed = true
+        shadowRuntimeElements.isCanBeResolved = false
+        shadowRuntimeElements.attributes { attrs ->
+          attrs.attribute(
+            Usage.USAGE_ATTRIBUTE,
+            objects.named(Usage::class.java, Usage.JAVA_RUNTIME),
+          )
+          attrs.attribute(
+            Category.CATEGORY_ATTRIBUTE,
+            objects.named(Category::class.java, Category.LIBRARY),
+          )
+          attrs.attribute(
+            LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+            objects.named(LibraryElements::class.java, LibraryElements.JAR),
+          )
+          attrs.attributeProvider(
+            Bundling.BUNDLING_ATTRIBUTE,
+            shadow.bundlingAttribute.map { attr -> objects.named(Bundling::class.java, attr) },
+          )
         }
+        shadowRuntimeElements.outgoing.artifact(tasks.shadowJar)
       }
-      shadowRuntimeElements.outgoing.artifact(tasks.shadowJar)
+
+    // `targetCompatibility` eagerly calls toolchainSpec, we need to defer it by afterEvaluate.
+    // https://github.com/gradle/gradle/blob/9e1a582adeb5ba12e6ad3807e62964806ea51bbb/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java#L119
+    afterEvaluate {
+      if (shadow.addTargetJvmVersionAttribute.get()) {
+        val compileJvmVersion =
+          compileClasspathConfig.get().attributes.getAttribute(TARGET_JVM_VERSION_ATTRIBUTE)
+        val targetJvmVersion =
+          compileJvmVersion ?: javaPluginExtension.targetCompatibility.majorVersion.toInt()
+        if (targetJvmVersion != Int.MAX_VALUE) {
+          logger.info(
+            "Setting target JVM version to {} for {} configuration.",
+            targetJvmVersion,
+            shadowRuntimeElements.name,
+          )
+          shadowRuntimeElements
+            .get()
+            .attributes
+            .attribute(TARGET_JVM_VERSION_ATTRIBUTE, targetJvmVersion)
+        } else {
+          logger.info(
+            "Cannot set the target JVM version to Int.MAX_VALUE when `java.autoTargetJvmDisabled` is enabled or in other cases."
+          )
+        }
+      } else {
+        logger.info(
+          "Skipping setting {} attribute for {} configuration.",
+          TARGET_JVM_VERSION_ATTRIBUTE,
+          shadowRuntimeElements.name,
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -75,29 +75,34 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
           Bundling.BUNDLING_ATTRIBUTE,
           shadow.bundlingAttribute.map { attr -> objects.named(Bundling::class.java, attr) },
         )
-        if (shadow.addTargetJvmVersionAttribute.get()) {
-          val compileJvmVersion =
-            compileClasspathConfig.get().attributes.getAttribute(TARGET_JVM_VERSION_ATTRIBUTE)
-          val targetJvmVersion =
-            compileJvmVersion ?: javaPluginExtension.targetCompatibility.majorVersion.toInt()
-          if (targetJvmVersion != Int.MAX_VALUE) {
-            logger.info(
-              "Setting target JVM version to {} for {} configuration.",
-              targetJvmVersion,
-              shadowRuntimeElements.name,
-            )
-            attrs.attribute(TARGET_JVM_VERSION_ATTRIBUTE, targetJvmVersion)
+
+        // `targetCompatibility` eagerly calls toolchainSpec, we need to defer it by afterEvaluate.
+        // https://github.com/gradle/gradle/blob/9e1a582adeb5ba12e6ad3807e62964806ea51bbb/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java#L119
+        afterEvaluate {
+          if (shadow.addTargetJvmVersionAttribute.get()) {
+            val compileJvmVersion =
+              compileClasspathConfig.get().attributes.getAttribute(TARGET_JVM_VERSION_ATTRIBUTE)
+            val targetJvmVersion =
+              compileJvmVersion ?: javaPluginExtension.targetCompatibility.majorVersion.toInt()
+            if (targetJvmVersion != Int.MAX_VALUE) {
+              logger.info(
+                "Setting target JVM version to {} for {} configuration.",
+                targetJvmVersion,
+                shadowRuntimeElements.name,
+              )
+              attrs.attribute(TARGET_JVM_VERSION_ATTRIBUTE, targetJvmVersion)
+            } else {
+              logger.info(
+                "Cannot set the target JVM version to Int.MAX_VALUE when `java.autoTargetJvmDisabled` is enabled or in other cases."
+              )
+            }
           } else {
             logger.info(
-              "Cannot set the target JVM version to Int.MAX_VALUE when `java.autoTargetJvmDisabled` is enabled or in other cases."
+              "Skipping setting {} attribute for {} configuration.",
+              TARGET_JVM_VERSION_ATTRIBUTE,
+              shadowRuntimeElements.name,
             )
           }
-        } else {
-          logger.info(
-            "Skipping setting {} attribute for {} configuration.",
-            TARGET_JVM_VERSION_ATTRIBUTE,
-            shadowRuntimeElements.name,
-          )
         }
       }
       shadowRuntimeElements.outgoing.artifact(tasks.shadowJar)


### PR DESCRIPTION
- Reverts #2055.
- Closes #2086.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
