### PR TITLE
Extract rules from dependency jars for R8 minification

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Extract R8 rules from dependency JARs when using `minimize { r8 { ... } }`.
+- Extract R8 rules from dependency JARs when using `minimize { r8 { ... } }`. ([#2089](https://github.com/GradleUp/shadow/pull/2089))
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.5.1...HEAD) - 2026-xx-xx
 
+### Added
+
+- Extract R8 rules from dependency JARs when using `minimize { r8 { ... } }`.
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -79,6 +79,7 @@ whole-program shrinking instead of the default dependency analyzer. R8 runs afte
 relocated the JAR, so service descriptors in `META-INF/services` are used to keep service providers.
 
 The default R8 configuration only shrinks unused code. It disables name minification and optimization.
+Shadow also extracts R8 rules published in dependency JARs, for example under `META-INF/proguard`.
 
 === "Kotlin"
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -7,8 +7,6 @@ import assertk.assertions.isEqualTo
 import com.github.jengelman.gradle.plugins.shadow.internal.MinimizeDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
-import com.github.jengelman.gradle.plugins.shadow.testkit.containsAtLeast
-import com.github.jengelman.gradle.plugins.shadow.testkit.containsNone
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
 import com.github.jengelman.gradle.plugins.shadow.testkit.getMainAttr
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
@@ -354,21 +352,27 @@ class CachingTest : BasePluginTest() {
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
-        containsAtLeast("server/Server.class", "client/Used.class", *manifestEntries)
-        containsNone("client/Reflective.class")
+        containsOnly(
+          "client/",
+          "client/Used.class",
+          "server/",
+          "server/Server.class",
+          *manifestEntries,
+        )
       }
 
       keepRules.writeText("-keep class client.Reflective { *; }")
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
-        containsAtLeast(
-          "server/Server.class",
+        containsOnly(
+          "client/",
           "client/Used.class",
           "client/Reflective.class",
+          "server/",
+          "server/Server.class",
           *manifestEntries,
         )
-        containsNone("client/Unused.class")
       }
       assertExecutionsFromCacheAndUpToDate()
     } finally {
@@ -387,8 +391,13 @@ class CachingTest : BasePluginTest() {
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
-        containsAtLeast("server/Server.class", "client/Used.class", *manifestEntries)
-        containsNone("client/Reflective.class")
+        containsOnly(
+          "client/",
+          "client/Used.class",
+          "server/",
+          "server/Server.class",
+          *manifestEntries,
+        )
       }
 
       path("client/src/main/resources/META-INF/proguard/client.pro")
@@ -396,13 +405,16 @@ class CachingTest : BasePluginTest() {
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
-        containsAtLeast(
-          "server/Server.class",
+        containsOnly(
+          "client/",
           "client/Used.class",
           "client/Reflective.class",
+          "server/",
+          "server/Server.class",
+          "META-INF/proguard/",
+          "META-INF/proguard/client.pro",
           *manifestEntries,
         )
-        containsNone("client/Unused.class")
       }
       assertExecutionsFromCacheAndUpToDate()
     } finally {

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -377,6 +377,40 @@ class CachingTest : BasePluginTest() {
   }
 
   @Test
+  fun r8ClasspathRuleChanged() {
+    val previousTaskPath = taskPath
+    taskPath = serverShadowJarPath
+    try {
+      writeR8Repository()
+      writeR8ClientAndServerModules()
+      path("server/r8-rules.pro").writeText("")
+
+      assertExecutionSuccess()
+      assertThat(outputServerShadowedJar).useAll {
+        containsAtLeast("server/Server.class", "client/Used.class", *manifestEntries)
+        containsNone("client/Reflective.class")
+      }
+
+      path("client/src/main/resources/META-INF/proguard/client.pro")
+        .writeText("-keep class client.Reflective { *; }")
+
+      assertExecutionSuccess()
+      assertThat(outputServerShadowedJar).useAll {
+        containsAtLeast(
+          "server/Server.class",
+          "client/Used.class",
+          "client/Reflective.class",
+          *manifestEntries,
+        )
+        containsNone("client/Unused.class")
+      }
+      assertExecutionsFromCacheAndUpToDate()
+    } finally {
+      taskPath = previousTaskPath
+    }
+  }
+
+  @Test
   fun relocatorChanged() {
     projectScript.appendText(
       """

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -387,6 +387,29 @@ class MinimizeTest : BasePluginTest() {
   }
 
   @Test
+  fun minimizeWithR8UsesClasspathRules() {
+    writeR8Repository()
+    writeR8ClientAndServerModules(
+      serverShadowBlock =
+        """
+        minimize {
+          r8 {}
+        }
+        """
+          .trimIndent()
+    )
+    path("client/src/main/resources/META-INF/proguard/client.pro")
+      .writeText("-keep class client.Reflective { *; }")
+
+    runWithSuccess(serverShadowJarPath)
+
+    assertThat(outputServerShadowedJar).useAll {
+      containsAtLeast("server/Server.class", "client/Used.class", "client/Reflective.class")
+      containsNone("client/Unused.class")
+    }
+  }
+
+  @Test
   fun minimizeWithR8CanEnableObfuscation() {
     writeR8Repository()
     writeR8ClientAndServerModules(

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -404,8 +404,16 @@ class MinimizeTest : BasePluginTest() {
     runWithSuccess(serverShadowJarPath)
 
     assertThat(outputServerShadowedJar).useAll {
-      containsAtLeast("server/Server.class", "client/Used.class", "client/Reflective.class")
-      containsNone("client/Unused.class")
+      containsOnly(
+        "client/",
+        "client/Used.class",
+        "client/Reflective.class",
+        "server/",
+        "server/Server.class",
+        "META-INF/proguard/",
+        "META-INF/proguard/client.pro",
+        *manifestEntries,
+      )
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -27,8 +27,9 @@ import org.gradle.process.ExecOperations
  * replacing the original jar.
  *
  * Generated rules are based on the final jar contents. Source-set classes are kept as roots,
- * dependencies excluded from minimization are kept, and service descriptors keep providers for
- * downstream `ServiceLoader` users. User rule files and inline rules are appended last.
+ * dependencies excluded from minimization are kept, service descriptors keep providers for
+ * downstream `ServiceLoader` users, and R8 consumer rules are extracted from the jar. User rule
+ * files and inline rules are appended last.
  *
  * The default R8 configuration is shrink-only. Shadow passes `--no-minification` to disable name
  * obfuscation and generates `-dontoptimize` unless optimization is enabled explicitly.
@@ -56,6 +57,7 @@ internal class R8Minimizer(
     }
 
     val r8Dir = temporaryDir.resolve("r8").also { it.mkdirs() }
+    val extractedRulesFile = r8Dir.resolve("classpath-rules.pro")
     val rulesFile = r8Dir.resolve("rules.pro")
     val r8Output = r8Dir.resolve("output.jar")
     val normalizedOutput = r8Dir.resolve("normalized-output.jar")
@@ -66,8 +68,12 @@ internal class R8Minimizer(
       throw GradleException("R8 minimization requires the java.home system property.")
     }
 
+    extractClasspathRules(inputJar, extractedRulesFile, launcher)
+
     val r8Args = r8Spec.args.get()
-    rulesFile.writeText(createRules(inputJar, r8Args).joinToString(System.lineSeparator()))
+    rulesFile.writeText(
+      createRules(inputJar, r8Args, extractedRulesFile).joinToString(System.lineSeparator())
+    )
 
     val arguments = buildList {
       add("--classfile")
@@ -95,7 +101,37 @@ internal class R8Minimizer(
     Files.move(normalizedOutput.toPath(), inputJar.toPath(), REPLACE_EXISTING)
   }
 
-  private fun createRules(inputJar: File, r8Args: List<String>): List<String> {
+  // R8's command line does not automatically apply consumer rules carried inside program jars.
+  // Extract them from the exact jar R8 will shrink, matching the classpath-rule handling used by
+  // Android builds.
+  private fun extractClasspathRules(
+    inputJar: File,
+    outputFile: File,
+    launcher: JavaLauncher?,
+  ) {
+    val arguments = buildList {
+      add("--rules-output")
+      add(outputFile.absolutePath)
+      add("--include-origin-comments")
+      add(inputJar.absolutePath)
+    }
+
+    logger.info("Extracting R8 rules from {}.", inputJar)
+    execOperations.javaexec {
+      it.classpath = r8Classpath
+      it.mainClass.set(R8_RULES_MAIN_CLASS)
+      if (launcher != null) {
+        it.executable = launcher.executablePath.asFile.absolutePath
+      }
+      it.args(arguments)
+    }
+  }
+
+  private fun createRules(
+    inputJar: File,
+    r8Args: List<String>,
+    extractedRulesFile: File,
+  ): List<String> {
     val rules = linkedSetOf<String>()
     if (shouldDisableOptimization(r8Args)) {
       rules += DefaultR8Spec.DONT_OPTIMIZE_RULE
@@ -103,11 +139,12 @@ internal class R8Minimizer(
     rules += sourceKeepRules(inputJar)
     rules += keptDependencyRules(inputJar)
     rules += serviceKeepRules(inputJar)
+    rules += extractedRulesFile.readLines()
     r8Spec.keepRuleFiles.files
       .sortedBy { it.absolutePath }
       .forEach { file ->
         if (file.isFile) {
-          rules += file.readText().lineSequence().toList()
+          rules += file.readLines()
         }
       }
     rules += r8Spec.keepRules.get()
@@ -335,6 +372,7 @@ internal class R8Minimizer(
 
   private companion object {
     const val R8_MAIN_CLASS = "com.android.tools.r8.R8"
+    const val R8_RULES_MAIN_CLASS = "com.android.tools.r8.ExtractR8Rules"
     const val SERVICES_PATH = "META-INF/services/"
     const val DEFAULT_DIR_MODE = 493 // 0755
     const val DEFAULT_FILE_MODE = 420 // 0644


### PR DESCRIPTION
This way libraries that embed their own proguard rules are respected

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
