### PR TITLE
Mark `ShadowDsl` for more types

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -9,8 +9,8 @@
 
 ### Changed
 
-- Mark `ShadowDslMarker` for `PatternFilterableResourceTransformer` and `ShadowJar`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
-  You shouldn't call `ShadowJar` members in `PatternFilterableResourceTransformer` blocks.
+- Apply `@ShadowDslMarker` to `PatternFilterableResourceTransformer` and `ShadowJar`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
+  This prevents Kotlin DSL from accidentally calling `ShadowJar` APIs inside `PatternFilterableResourceTransformer` configuration blocks.
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,6 +7,11 @@
 
 - Extract R8 rules from dependency JARs when using `minimize { r8 { ... } }`. ([#2089](https://github.com/GradleUp/shadow/pull/2089))
 
+### Changed
+
+- Mark `ShadowDslMarker` for `PatternFilterableResourceTransformer` and `ShadowJar`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
+  You shouldn't call `ShadowJar` members in `PatternFilterableResourceTransformer` blocks.
+
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 
 ### Fixed

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - Rename `ShadowDslMarker` to `ShadowDsl`. ([#2091](https://github.com/GradleUp/shadow/pull/2091))
-- Apply `@ShadowDslMarker` to `ShadowJar`, `ResourceTransformer`, `DependencyFilter`, and `Relocator`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
+- Apply `@ShadowDsl` to `ShadowJar`, `ResourceTransformer`, `DependencyFilter`, and `Relocator`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
   This restricts nested DSL configuration blocks from implicitly calling outer receiver APIs in Kotlin script files.
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -9,8 +9,8 @@
 
 ### Changed
 
-- Apply `@ShadowDslMarker` to `PatternFilterableResourceTransformer` and `ShadowJar`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
-  This prevents Kotlin DSL from accidentally calling `ShadowJar` APIs inside `PatternFilterableResourceTransformer` configuration blocks.
+- Apply `@ShadowDslMarker` to `ShadowJar`, `ResourceTransformer`, `DependencyFilter`, and `Relocator`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
+  This restricts nested DSL configuration blocks from implicitly calling outer receiver APIs in Kotlin script files.
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - Rename `ShadowDslMarker` to `ShadowDsl`. ([#2091](https://github.com/GradleUp/shadow/pull/2091))
-- Apply `@ShadowDsl` to `ShadowJar`, `ResourceTransformer`, `DependencyFilter`, and `Relocator`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
+- **POTENTIALLY BREAKING:** Apply `@ShadowDsl` to `ShadowJar`, `ResourceTransformer`, `DependencyFilter`, and `Relocator`. ([#2090](https://github.com/GradleUp/shadow/pull/2090))  
   This restricts nested DSL configuration blocks from implicitly calling outer receiver APIs in Kotlin script files.
 
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.relocation
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import org.gradle.api.tasks.Input
 
@@ -11,7 +11,7 @@ import org.gradle.api.tasks.Input
  * @author Jason van Zyl
  * @author John Engelman
  */
-@ShadowDslMarker
+@ShadowDsl
 public interface Relocator {
   public fun canRelocatePath(path: String): Boolean
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/Relocator.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.relocation
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import org.gradle.api.tasks.Input
 
@@ -10,6 +11,7 @@ import org.gradle.api.tasks.Input
  * @author Jason van Zyl
  * @author John Engelman
  */
+@ShadowDslMarker
 public interface Relocator {
   public fun canRelocatePath(path: String): Boolean
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import java.io.Serializable
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -14,7 +14,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Internal
 
 // DependencyFilter is used as Gradle Input in ShadowJar, so it must be Serializable.
-@ShadowDslMarker
+@ShadowDsl
 public interface DependencyFilter : Serializable {
   /** Resolve a [configuration] against the [include]/[exclude] rules in the filter. */
   public fun resolve(configuration: Configuration): FileCollection

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import java.io.Serializable
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -13,6 +14,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Internal
 
 // DependencyFilter is used as Gradle Input in ShadowJar, so it must be Serializable.
+@ShadowDslMarker
 public interface DependencyFilter : Serializable {
   /** Resolve a [configuration] against the [include]/[exclude] rules in the filter. */
   public fun resolve(configuration: Configuration): FileCollection

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/MinimizeSpec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/MinimizeSpec.kt
@@ -1,12 +1,10 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import org.gradle.api.Action
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
 /** Configures how [ShadowJar.minimize] removes unused code from the shadowed JAR. */
-@ShadowDsl
 public interface MinimizeSpec : DependencyFilter {
   /**
    * The tool used to minimize the shadowed JAR.

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -3,7 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.R8_CONFIGURATION_NAME
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.shadow
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultInheritManifest
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultMinimizeSpec
@@ -72,7 +72,7 @@ import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.ExecOperations
 
-@ShadowDslMarker
+@ShadowDsl
 @CacheableTask
 public abstract class ShadowJar : Jar() {
   private val defaultMinimizeSpec = objectFactory.newInstance(DefaultMinimizeSpec::class.java)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -3,6 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.R8_CONFIGURATION_NAME
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.shadow
+import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultInheritManifest
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultMinimizeSpec
@@ -71,6 +72,7 @@ import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.ExecOperations
 
+@ShadowDslMarker
 @CacheableTask
 public abstract class ShadowJar : Jar() {
   private val defaultMinimizeSpec = objectFactory.newInstance(DefaultMinimizeSpec::class.java)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer.kt
@@ -1,6 +1,5 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import com.github.jengelman.gradle.plugins.shadow.internal.unsafeLazy
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
@@ -14,7 +13,6 @@ import org.gradle.api.tasks.util.PatternSet
  *
  * @param patternSet The [PatternSet] used for filtering resources.
  */
-@ShadowDslMarker
 public abstract class PatternFilterableResourceTransformer(
   @Internal public val patternSet: PatternSet
 ) : ResourceTransformer by ResourceTransformer.Companion, PatternFilterable by patternSet {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import com.github.jengelman.gradle.plugins.shadow.internal.unsafeLazy
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
@@ -13,6 +14,7 @@ import org.gradle.api.tasks.util.PatternSet
  *
  * @param patternSet The [PatternSet] used for filtering resources.
  */
+@ShadowDslMarker
 public abstract class PatternFilterableResourceTransformer(
   @Internal public val patternSet: PatternSet
 ) : ResourceTransformer by ResourceTransformer.Companion, PatternFilterable by patternSet {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import com.github.jengelman.gradle.plugins.shadow.relocation.CacheableRelocator
 import java.io.IOException
 import org.apache.tools.zip.ZipOutputStream
@@ -17,7 +17,7 @@ import org.gradle.api.tasks.Internal
  * @author Charlie Knudsen
  * @author John Engelman
  */
-@ShadowDslMarker
+@ShadowDsl
 public interface ResourceTransformer : Named {
   public fun canTransformResource(element: FileTreeElement): Boolean
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
 import com.github.jengelman.gradle.plugins.shadow.relocation.CacheableRelocator
 import java.io.IOException
 import org.apache.tools.zip.ZipOutputStream
@@ -16,6 +17,7 @@ import org.gradle.api.tasks.Internal
  * @author Charlie Knudsen
  * @author John Engelman
  */
+@ShadowDslMarker
 public interface ResourceTransformer : Named {
   public fun canTransformResource(element: FileTreeElement): Boolean
 


### PR DESCRIPTION
This prevents the accidential calls from `PatternFilterableResourceTransformer` blocks.

`ShadowJar` → `CopySpec` → `PatternFilterable`
`PatternFilterableResourceTransformer` → `PatternFilterable`

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
