### PR TITLE
Rename `ShadowDslMarker` to `ShadowDsl`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -41,6 +41,9 @@ public final class com/github/jengelman/gradle/plugins/shadow/ShadowBasePlugin$C
 	public final synthetic fun getShadow (Lorg/gradle/api/artifacts/ConfigurationContainer;)Lorg/gradle/api/NamedDomainObjectProvider;
 }
 
+public abstract interface annotation class com/github/jengelman/gradle/plugins/shadow/ShadowDsl : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/github/jengelman/gradle/plugins/shadow/ShadowDslMarker : java/lang/annotation/Annotation {
 }
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,6 +7,10 @@
 
 - Extract R8 rules from dependency JARs when using `minimize { r8 { ... } }`. ([#2089](https://github.com/GradleUp/shadow/pull/2089))
 
+### Changed
+
+- Rename `ShadowDslMarker` to `ShadowDsl`. ([#2091](https://github.com/GradleUp/shadow/pull/2091))
+
 ## [9.5.1](https://github.com/GradleUp/shadow/releases/tag/9.5.1) - 2026-07-06
 
 ### Fixed

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
@@ -5,7 +5,7 @@ package com.github.jengelman.gradle.plugins.shadow
 
 @Deprecated(
   message = "Use `ShadowDsl` instead. This will be removed in Shadow 10.",
-  replaceWith = ReplaceWith("ShadowDsl", "com.github.jengelman.gradle.plugins.shadow"),
+  replaceWith = ReplaceWith("ShadowDsl", "com.github.jengelman.gradle.plugins.shadow.ShadowDsl"),
   level = DeprecationLevel.HIDDEN,
 )
 @DslMarker

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
@@ -6,7 +6,6 @@ package com.github.jengelman.gradle.plugins.shadow
 @Deprecated(
   message = "Use `ShadowDsl` instead. This will be removed in Shadow 10.",
   replaceWith = ReplaceWith("ShadowDsl", "com.github.jengelman.gradle.plugins.shadow.ShadowDsl"),
-  level = DeprecationLevel.HIDDEN,
 )
 @DslMarker
 public annotation class ShadowDslMarker

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDsl.kt
@@ -1,0 +1,12 @@
+package com.github.jengelman.gradle.plugins.shadow
+
+/** Restricts nested Shadow DSL blocks from accidentally calling outer receiver APIs. */
+@DslMarker public annotation class ShadowDsl
+
+@Deprecated(
+  message = "Use `ShadowDsl` instead. This will be removed in Shadow 10.",
+  replaceWith = ReplaceWith("ShadowDsl", "com.github.jengelman.gradle.plugins.shadow"),
+  level = DeprecationLevel.HIDDEN,
+)
+@DslMarker
+public annotation class ShadowDslMarker

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDslMarker.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowDslMarker.kt
@@ -1,4 +1,0 @@
-package com.github.jengelman.gradle.plugins.shadow
-
-/** Restricts nested Shadow DSL blocks from accidentally calling outer receiver APIs. */
-@DslMarker public annotation class ShadowDslMarker

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/MinimizeSpec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/MinimizeSpec.kt
@@ -1,12 +1,12 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import org.gradle.api.Action
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
 /** Configures how [ShadowJar.minimize] removes unused code from the shadowed JAR. */
-@ShadowDslMarker
+@ShadowDsl
 public interface MinimizeSpec : DependencyFilter {
   /**
    * The tool used to minimize the shadowed JAR.

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -1,6 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
-import com.github.jengelman.gradle.plugins.shadow.ShadowDslMarker
+import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
 /** Minimal R8 configuration for [ShadowJar.minimize]. */
-@ShadowDslMarker
+@ShadowDsl
 public interface R8Spec {
   /**
    * Additional R8 command line arguments.


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
