### PR TITLE
Bump min Gradle requirement to 9.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-24.04-arm, windows-latest ]
         # Test on the minimum Gradle version and the latest.
-        gradle: [ 9.2.0, current ]
+        gradle: [ 9.4.0, current ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Gradle plugin for creating fat/uber JARs with support for package relocation.
 | 9.2.0+         | 8.11               | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 | 9.3.0+         | 9.0                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 | 9.5.0+         | 9.2                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
+| 9.7.0+         | 9.4                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ dependent libraries into the output jar without incurring the I/O overhead of ex
 | 9.2.0+         | 8.11               | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 | 9.3.0+         | 9.0                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 | 9.5.0+         | 9.2                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
+| 9.7.0+         | 9.4                | 17               | [`com.gradleup.shadow`][gradleup's]                  |
 
 ## Benefits of Shadow
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.6.1...HEAD) - 2026-xx-xx
 
+### Changed
+
+- Bump min Gradle requirement to 9.4.0. ([#2114](https://github.com/GradleUp/shadow/pull/2114))
+
 ### Deprecated
 
 - Deprecate `keepRules` and `keepRuleFiles` in `R8Spec`. ([#2120](https://github.com/GradleUp/shadow/pull/2120))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-minGradle = "9.2.0"
+minGradle = "9.4.0"
 kotlin = "2.4.10"
 moshi = "1.15.2"
 pluginPublish = "2.1.1"

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/JavaPluginsTest.kt
@@ -23,7 +23,6 @@ import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import com.github.jengelman.gradle.plugins.shadow.testkit.getMainAttr
 import com.github.jengelman.gradle.plugins.shadow.testkit.getStream
-import com.github.jengelman.gradle.plugins.shadow.testkit.testGradleVersion
 import com.github.jengelman.gradle.plugins.shadow.util.Issue
 import com.github.jengelman.gradle.plugins.shadow.util.prependText
 import com.github.jengelman.gradle.plugins.shadow.util.runProcess
@@ -43,7 +42,6 @@ import org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME
 import org.gradle.api.tasks.bundling.ZipEntryCompression
 import org.gradle.language.base.plugins.LifecycleBasePlugin.ASSEMBLE_TASK_NAME
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
-import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -672,17 +670,10 @@ class JavaPluginsTest : BasePluginTest() {
   fun moveLocalGradleApiToCompileOnly() {
     projectScript.writeText(getDefaultProjectBuildScript("java-gradle-plugin"))
 
-    val outputCompileOnly = dependencies(COMPILE_ONLY_CONFIGURATION_NAME)
     val outputCompileOnlyApi = dependencies(COMPILE_ONLY_API_CONFIGURATION_NAME)
-    val outputApi = dependencies(API_CONFIGURATION_NAME)
 
     // "unspecified" is the local Gradle API.
-    if (GradleVersion.version(testGradleVersion) >= GradleVersion.version("9.4.0")) {
-      assertThat(outputCompileOnlyApi).contains("unspecified")
-    } else {
-      assertThat(outputCompileOnly).contains("unspecified")
-      assertThat(outputApi).doesNotContain("unspecified")
-    }
+    assertThat(outputCompileOnlyApi).contains("unspecified")
   }
 
   @Issue("https://github.com/GradleUp/shadow/issues/1422")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -2,9 +2,7 @@ package com.github.jengelman.gradle.plugins.shadow
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.SHADOW
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.Companion.shadow
-import com.github.jengelman.gradle.plugins.shadow.internal.extendsFromCompat
 import com.github.jengelman.gradle.plugins.shadow.internal.javaPluginExtension
-import com.github.jengelman.gradle.plugins.shadow.internal.moveGradleApiIntoCompileOnly
 import com.github.jengelman.gradle.plugins.shadow.internal.runtimeConfiguration
 import com.github.jengelman.gradle.plugins.shadow.internal.sourceSets
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.registerShadowJarCommon
@@ -52,11 +50,11 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     val shadowConfig = configurations.shadow
     val compileClasspathConfig =
       configurations.named(COMPILE_CLASSPATH_CONFIGURATION_NAME) { compileClasspath ->
-        compileClasspath.extendsFromCompat(shadowConfig)
+        compileClasspath.extendsFrom(shadowConfig)
       }
     val shadowRuntimeElements =
       configurations.register(SHADOW_RUNTIME_ELEMENTS_CONFIGURATION_NAME) { shadowRuntimeElements ->
-        shadowRuntimeElements.extendsFromCompat(shadowConfig)
+        shadowRuntimeElements.extendsFrom(shadowConfig)
         shadowRuntimeElements.isCanBeConsumed = true
         shadowRuntimeElements.isCanBeResolved = false
         shadowRuntimeElements.attributes { attrs ->
@@ -140,9 +138,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     }
   }
 
-  protected open fun Project.configureJavaGradlePlugin() {
-    moveGradleApiIntoCompileOnly()
-  }
+  protected open fun Project.configureJavaGradlePlugin() {}
 
   public companion object {
     public const val COMPONENT_NAME: String = SHADOW

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
@@ -10,8 +10,6 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME
-import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -20,7 +18,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.jvm.toolchain.JavaToolchainService
-import org.gradle.util.GradleVersion
 
 /** Return `runtimeClasspath` or `runtime` configuration. */
 internal inline val Project.runtimeConfiguration: Configuration
@@ -59,39 +56,6 @@ internal fun Project.addBuildScanCustomValues() {
     buildScan.buildFinished {
       buildScan.value("shadow.${task.path}.executed", "true")
       buildScan.value("shadow.${task.path}.didWork", task.didWork.toString())
-    }
-  }
-}
-
-// TODO: this could be removed after bumping the min Gradle requirement to 9.4 or above.
-internal fun Configuration.extendsFromCompat(vararg superConfigs: Provider<out Configuration>) {
-  if (GradleVersion.current() >= GradleVersion.version("9.4.0")) {
-    @Suppress("UnstableApiUsage") extendsFrom(*superConfigs)
-  } else {
-    extendsFrom(*superConfigs.map { it.get() }.toTypedArray())
-  }
-}
-
-// TODO: this could be removed after bumping the min Gradle requirement to 9.4 or above.
-internal fun Project.moveGradleApiIntoCompileOnly() {
-  // gradleApi has been added into compileOnlyApi since Gradle 9.4.0.
-  if (GradleVersion.current() >= GradleVersion.version("9.4.0")) return
-
-  // org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
-  plugins.withId("org.gradle.java-gradle-plugin") {
-    val gradleApi = dependencies.gradleApi()
-    // Remove the gradleApi so it isn't merged into the jar file.
-    // This is required because 'java-gradle-plugin' adds gradleApi() to the 'api' configuration.
-    // See
-    // https://github.com/gradle/gradle/blob/972c3e5c6ef990dd2190769c1ce31998a9402a79/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L161.
-    configurations.named(API_CONFIGURATION_NAME) { api ->
-      // Only proceed if the removal is successful.
-      if (!api.dependencies.remove(gradleApi)) return@named
-      // Compile only gradleApi() to make sure the plugin can compile against Gradle API.
-      configurations
-        .getByName(COMPILE_ONLY_CONFIGURATION_NAME)
-        .dependencies
-        .add(dependencies.gradleApi())
     }
   }
 }


### PR DESCRIPTION
Aims for release `9.7.0`.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
