### PR TITLE
Preserve repeated lines in R8 rule files

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Preserve repeated lines in R8 rule files when using `minimize { r8 { ... } }`.
+- Preserve repeated lines in R8 rule files when using `minimize { r8 { ... } }`. ([#2115](https://github.com/GradleUp/shadow/pull/2115))
 
 ## [9.6.0](https://github.com/GradleUp/shadow/releases/tag/9.6.0) - 2026-07-16
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -6,6 +6,10 @@
 
 - Use `GradleException` for expected build failures. ([#2113](https://github.com/GradleUp/shadow/pull/2113))
 
+### Fixed
+
+- Preserve repeated lines in R8 rule files when using `minimize { r8 { ... } }`.
+
 ## [9.6.0](https://github.com/GradleUp/shadow/releases/tag/9.6.0) - 2026-07-16
 
 ### Added

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -418,6 +418,48 @@ class MinimizeTest : BasePluginTest() {
   }
 
   @Test
+  fun minimizeWithR8PreservesRepeatedLinesInClasspathRules() {
+    writeR8Repository()
+    writeR8ClientAndServerModules(
+      serverShadowBlock =
+        """
+        minimize {
+          r8 {}
+        }
+        """
+          .trimIndent()
+    )
+    path("client/src/main/resources/META-INF/proguard/client.pro")
+      .writeText(
+        """
+        -keep class client.Reflective {
+          public <init>();
+        }
+        -keep class client.Unused {
+          public <init>();
+        }
+        """
+          .trimIndent()
+      )
+
+    runWithSuccess(serverShadowJarPath)
+
+    assertThat(outputServerShadowedJar).useAll {
+      containsOnly(
+        "client/",
+        "client/Used.class",
+        "client/Reflective.class",
+        "client/Unused.class",
+        "server/",
+        "server/Server.class",
+        "META-INF/proguard/",
+        "META-INF/proguard/client.pro",
+        *manifestEntries,
+      )
+    }
+  }
+
+  @Test
   fun minimizeWithR8CanEnableObfuscation() {
     writeR8Repository()
     writeR8ClientAndServerModules(

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -132,23 +132,23 @@ internal class R8Minimizer(
     r8Args: List<String>,
     extractedRulesFile: File,
   ): List<String> {
-    val rules = linkedSetOf<String>()
-    if (shouldDisableOptimization(r8Args)) {
-      rules += DefaultR8Spec.DONT_OPTIMIZE_RULE
-    }
-    rules += sourceKeepRules(inputJar)
-    rules += keptDependencyRules(inputJar)
-    rules += serviceKeepRules(inputJar)
-    rules += extractedRulesFile.readLines()
-    r8Spec.keepRuleFiles.files
-      .sortedBy { it.absolutePath }
-      .forEach { file ->
-        if (file.isFile) {
-          rules += file.readLines()
-        }
+    return buildList {
+      if (shouldDisableOptimization(r8Args)) {
+        add(DefaultR8Spec.DONT_OPTIMIZE_RULE)
       }
-    rules += r8Spec.keepRules.get()
-    return rules.toList()
+      addAll(sourceKeepRules(inputJar))
+      addAll(keptDependencyRules(inputJar))
+      addAll(serviceKeepRules(inputJar))
+      addAll(extractedRulesFile.readLines())
+      r8Spec.keepRuleFiles.files
+        .sortedBy { it.absolutePath }
+        .forEach { file ->
+          if (file.isFile) {
+            addAll(file.readLines())
+          }
+        }
+      addAll(r8Spec.keepRules.get())
+    }
   }
 
   private fun shouldDisableOptimization(r8Args: List<String>): Boolean {


### PR DESCRIPTION
Previously we were using a set, which would break multi-line rules since we read them line-by-line