### PR TITLE
Update changelog item for `enableKotlinModuleRemapping` flag

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -52,6 +52,7 @@
 - Remove `afterEvaluate` when adding variants. ([#2056](https://github.com/GradleUp/shadow/pull/2056))
 - Deprecate `enableKotlinModuleRemapping` for `ShadowJar`. ([#2073](https://github.com/GradleUp/shadow/pull/2073))  
   Apply `KotlinModuleMetadataTransformer` explicitly to support relocating inside Kotlin module metadata files.
+  This flag will be disabled and removed in the next major release.
 - Deprecate everything under `ShadowCopyAction`. ([#2083](https://github.com/GradleUp/shadow/pull/2083))
 
 ### Fixed


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
