### PR TITLE
Deprecate `keepRules` and `keepRuleFiles` in `R8Spec`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -226,8 +226,10 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 	public abstract fun enableObfuscation ()V
 	public abstract fun enableOptimization ()V
 	public abstract fun getArgs ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getKeepRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getKeepRules ()Lorg/gradle/api/provider/ListProperty;
+	public fun getKeepRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public fun getKeepRules ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getProguardRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getProguardRules ()Lorg/gradle/api/provider/ListProperty;
 }
 
 public class com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction : org/gradle/api/internal/file/copy/CopyAction {

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.6.1...HEAD) - 2026-xx-xx
 
+### Deprecated
+
+- Deprecate `keepRules` and `keepRuleFiles` in `R8Spec`. ([#2120](https://github.com/GradleUp/shadow/pull/2120))
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -92,8 +92,8 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
       minimize {
         r8 {
           // Optional extra configuration
-          keepRules.add("-keep class com.example.ReflectiveApi { *; }")
-          keepRuleFiles.from(layout.projectDirectory.file("r8-rules.pro"))
+          proguardRules.add("-keep class com.example.ReflectiveApi { *; }")
+          proguardRuleFiles.from(layout.projectDirectory.file("r8-rules.pro"))
         }
       }
     }
@@ -110,8 +110,8 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
       minimize {
         r8 {
           // Optional extra configuration
-          keepRules.add('-keep class com.example.ReflectiveApi { *; }')
-          keepRuleFiles.from(layout.projectDirectory.file('r8-rules.pro'))
+          proguardRules.add('-keep class com.example.ReflectiveApi { *; }')
+          proguardRuleFiles.from(layout.projectDirectory.file('r8-rules.pro'))
         }
       }
     }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -347,8 +347,8 @@ class CachingTest : BasePluginTest() {
     try {
       writeR8Repository()
       writeR8ClientAndServerModules()
-      val keepRules = path("server/r8-rules.pro")
-      keepRules.writeText("")
+      val proguardRules = path("server/r8-rules.pro")
+      proguardRules.writeText("")
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
@@ -361,7 +361,7 @@ class CachingTest : BasePluginTest() {
         )
       }
 
-      keepRules.writeText("-keep class client.Reflective { *; }")
+      proguardRules.writeText("-keep class client.Reflective { *; }")
 
       assertExecutionSuccess()
       assertThat(outputServerShadowedJar).useAll {
@@ -670,7 +670,7 @@ class CachingTest : BasePluginTest() {
         $shadowJarTask {
           minimize {
             r8 {
-              keepRuleFiles.from(file("r8-rules.pro"))
+              proguardRuleFiles.from(file("r8-rules.pro"))
             }
           }
         }

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -358,14 +358,14 @@ class MinimizeTest : BasePluginTest() {
   }
 
   @Test
-  fun minimizeWithR8HonorsCustomKeepRules() {
+  fun minimizeWithR8HonorsCustomProguardRules() {
     writeR8Repository()
     writeR8ClientAndServerModules(
       serverShadowBlock =
         """
         minimize {
           r8 {
-            keepRules.add("-keep class client.Reflective { *; }")
+            proguardRules.add("-keep class client.Reflective { *; }")
           }
         }
         """

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
@@ -17,9 +17,9 @@ internal open class DefaultR8Spec @Inject constructor(objectFactory: ObjectFacto
 
   override val args: ListProperty<String> = objectFactory.listProperty(defaultArgs)
 
-  override val keepRules: ListProperty<String> = objectFactory.listProperty()
+  override val proguardRules: ListProperty<String> = objectFactory.listProperty()
 
-  override val keepRuleFiles: ConfigurableFileCollection = objectFactory.fileCollection()
+  override val proguardRuleFiles: ConfigurableFileCollection = objectFactory.fileCollection()
 
   override fun enableObfuscation() {
     defaultArgs.set(emptyList())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -136,18 +136,18 @@ internal class R8Minimizer(
       if (shouldDisableOptimization(r8Args)) {
         add(DefaultR8Spec.DONT_OPTIMIZE_RULE)
       }
-      addAll(sourceKeepRules(inputJar))
+      addAll(sourceProguardRules(inputJar))
       addAll(keptDependencyRules(inputJar))
-      addAll(serviceKeepRules(inputJar))
+      addAll(serviceProguardRules(inputJar))
       addAll(extractedRulesFile.readLines())
-      r8Spec.keepRuleFiles.files
+      r8Spec.proguardRuleFiles.files
         .sortedBy { it.absolutePath }
         .forEach { file ->
           if (file.isFile) {
             addAll(file.readLines())
           }
         }
-      addAll(r8Spec.keepRules.get())
+      addAll(r8Spec.proguardRules.get())
     }
   }
 
@@ -158,7 +158,7 @@ internal class R8Minimizer(
 
   // Project classes are the public surface of the shadowed jar, even when nothing in the input jar
   // refers to every class directly.
-  private fun sourceKeepRules(inputJar: File): List<String> {
+  private fun sourceProguardRules(inputJar: File): List<String> {
     val jarClasses = jarClassEntries(inputJar)
     return sourceSetsClassesDirs
       .asSequence()
@@ -198,7 +198,7 @@ internal class R8Minimizer(
 
   // Service descriptors are usage edges for downstream ServiceLoader calls, so keep the service
   // interface and every listed provider even if R8 sees no direct references.
-  private fun serviceKeepRules(inputJar: File): List<String> {
+  private fun serviceProguardRules(inputJar: File): List<String> {
     val rules = linkedSetOf<String>()
     JarFile(inputJar).use { jarFile ->
       jarFile

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -18,13 +18,30 @@ public interface R8Spec {
    */
   @get:Input public val args: ListProperty<String>
 
-  /** Additional ProGuard/R8 keep rules. */
-  @get:Input public val keepRules: ListProperty<String>
+  @Deprecated(
+    message = "Use `proguardRules` instead. This will be removed in Shadow 10.",
+    replaceWith = ReplaceWith("proguardRules"),
+  )
+  @get:Input
+  public val keepRules: ListProperty<String>
+    get() = proguardRules
 
-  /** Files containing additional ProGuard/R8 keep rules. */
+  /** Additional ProGuard/R8 rules. */
+  @get:Input public val proguardRules: ListProperty<String>
+
+  @Deprecated(
+    message = "Use `proguardRuleFiles` instead. This will be removed in Shadow 10.",
+    replaceWith = ReplaceWith("proguardRuleFiles"),
+  )
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   public val keepRuleFiles: ConfigurableFileCollection
+    get() = proguardRuleFiles
+
+  /** Files containing additional ProGuard/R8 rules. */
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  public val proguardRuleFiles: ConfigurableFileCollection
 
   /**
    * Enable R8 name obfuscation while keeping Shadow's default no-optimization behavior.

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
@@ -39,8 +39,8 @@ class MinimizeSpecsTest {
       assertThat(args.get()).containsExactly(DefaultR8Spec.NO_MINIFICATION_ARG)
       assertThat(obfuscationEnabled.get()).isFalse()
       assertThat(optimizationEnabled.get()).isFalse()
-      assertThat(keepRules.get()).isEmpty()
-      assertThat(keepRuleFiles.files).isEmpty()
+      assertThat(proguardRules.get()).isEmpty()
+      assertThat(proguardRuleFiles.files).isEmpty()
     }
 
   @Test


### PR DESCRIPTION
Follow up https://github.com/GradleUp/shadow/pull/2077#discussion_r3637173355.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
