### PR TITLE
Allow configuring the final R8 configuration file with `R8Spec.configurationFile`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -226,6 +226,7 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 	public abstract fun enableObfuscation ()V
 	public abstract fun enableOptimization ()V
 	public abstract fun getArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getConfigurationFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public fun getKeepRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getKeepRules ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getProguardRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Allow configuring the final R8 ProGuard configuration file with `R8Spec.configurationFile`.
+- Allow configuring the final R8 ProGuard configuration file with `R8Spec.configurationFile`. ([#2133](https://github.com/GradleUp/shadow/pull/2133))
 
 ### Changed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Allow configuring the final R8 ProGuard configuration file with `R8Spec.configurationFile`. ([#2133](https://github.com/GradleUp/shadow/pull/2133))
+- Allow configuring the final R8 configuration file with `R8Spec.configurationFile`. ([#2133](https://github.com/GradleUp/shadow/pull/2133))
 
 ### Changed
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased](https://github.com/GradleUp/shadow/compare/9.6.1...HEAD) - 2026-xx-xx
 
+### Added
+
+- Allow configuring the final R8 ProGuard configuration file with `R8Spec.configurationFile`.
+
 ### Changed
 
 - Bump min Gradle requirement to 9.4.0. ([#2114](https://github.com/GradleUp/shadow/pull/2114))

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -122,6 +122,67 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
 Shadow writes the final generated ProGuard configuration to
 `build/shadowJar/configuration.txt` by default. Set `configurationFile` to retain it elsewhere.
 
+R8 also supports ProGuard reporting options such as
+[`-printmapping`](https://www.guardsquare.com/manual/configuration/usage#printmapping),
+[`-printseeds`](https://www.guardsquare.com/manual/configuration/usage#printseeds), and
+[`-printusage`](https://www.guardsquare.com/manual/configuration/usage#printusage). Add them as
+`proguardRules` when you want to retain name mappings, matched keep rules, or removed code:
+
+=== "Kotlin"
+
+    ```kotlin
+    repositories {
+      google()
+    }
+
+    tasks.shadowJar {
+      minimize {
+        r8 {
+          enableObfuscation()
+          configurationFile.set(layout.buildDirectory.file("r8/configuration.txt"))
+          proguardRules.addAll(
+            "-printmapping reports/mapping.txt",
+            "-printseeds reports/seeds.txt",
+            "-printusage reports/usage.txt",
+          )
+        }
+      }
+    }
+    ```
+
+=== "Groovy"
+
+    ```groovy
+    repositories {
+      google()
+    }
+
+    tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      minimize {
+        r8 {
+          enableObfuscation()
+          configurationFile.set(layout.buildDirectory.file('r8/configuration.txt'))
+          proguardRules.addAll(
+            '-printmapping reports/mapping.txt',
+            '-printseeds reports/seeds.txt',
+            '-printusage reports/usage.txt',
+          )
+        }
+      }
+    }
+    ```
+
+Relative report paths are resolved from the directory containing `configurationFile`. The example above writes the
+reports under `build/r8/reports`. Use absolute paths if the reports must be written independently of the configuration
+file location. This behavior follows
+[R8's configuration parser](https://r8.googlesource.com/r8/+/refs/tags/9.1.31/src/main/java/com/android/tools/r8/shaking/ProguardConfigurationParser.java).
+`-printmapping` only contains renamed items, so call `enableObfuscation()` when you need a useful mapping.
+
+These reporting options belong in the build's R8 configuration, not in rules published inside a dependency JAR.
+Android's
+[library optimization guidance](https://developer.android.com/topic/performance/app-optimization/library-optimization#optimization-requirements)
+lists them among the global options that library authors should not publish as consumer keep rules.
+
 Shadow resolves R8 from the `shadowR8` configuration. The default dependency is `com.android.tools:r8`, which is
 published by Google Maven rather than Maven Central. Add `google()` to your repositories or override the dependency:
 

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -119,7 +119,7 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
     }
     ```
 
-R8 writes the collective ProGuard configuration it used to `build/shadowJar/configuration.txt` by default. Shadow
+R8 writes the collective ProGuard configuration it used to `build/shadowJar/r8/configuration.txt` by default. Shadow
 passes this location to R8 with `--pg-conf-output`. Set `configurationFile` to retain it elsewhere.
 
 R8 also supports ProGuard reporting options such as

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -74,7 +74,7 @@ Similar to [`ShadowJar.dependencies`][ShadowJar.dependencies], projects can also
 
 ## Minimizing with R8
 
-Shadow can also run [R8](https://r8.googlesource.com/r8) over the final shadowed JAR. This is useful when you want
+Shadow can also run [R8][R8] over the final shadowed JAR. This is useful when you want
 whole-program shrinking instead of the default dependency analyzer. R8 runs after Shadow has merged, transformed, and
 relocated the JAR, so service descriptors in `META-INF/services` are used to keep service providers.
 
@@ -123,10 +123,12 @@ R8 writes the collective ProGuard configuration it used to `build/shadowJar/r8/c
 passes this location to R8 with `--pg-conf-output`. Set `configurationFile` to retain it elsewhere.
 
 R8 also supports ProGuard reporting options such as
-[`-printmapping`](https://www.guardsquare.com/manual/configuration/usage#printmapping),
-[`-printseeds`](https://www.guardsquare.com/manual/configuration/usage#printseeds), and
-[`-printusage`](https://www.guardsquare.com/manual/configuration/usage#printusage). Add them as
-`proguardRules` when you want to retain name mappings, matched keep rules, or removed code:
+
+- [`-printmapping`][-printmapping]
+- [`-printseeds`][-printseeds]
+- [`-printusage`][-printusage]
+
+Add them as `proguardRules` when you want to retain name mappings, matched keep rules, or removed code:
 
 === "Kotlin"
 
@@ -175,12 +177,12 @@ R8 also supports ProGuard reporting options such as
 Relative report paths are resolved from the directory containing `configurationFile`. The example above writes the
 reports under `build/r8/reports`. Use absolute paths if the reports must be written independently of the configuration
 file location. This behavior follows
-[R8's configuration parser](https://r8.googlesource.com/r8/+/refs/tags/9.1.31/src/main/java/com/android/tools/r8/shaking/ProguardConfigurationParser.java).
+[R8's configuration parser][ProguardConfigurationParser].
 `-printmapping` only contains renamed items, so call `enableObfuscation()` when you need a useful mapping.
 
 These reporting options belong in the build's R8 configuration, not in rules published inside a dependency JAR.
 Android's
-[library optimization guidance](https://developer.android.com/topic/performance/app-optimization/library-optimization#optimization-requirements)
+[library optimization guidance][library-optimization-guidance]
 lists them among the global options that library authors should not publish as consumer keep rules.
 
 Shadow resolves R8 from the `shadowR8` configuration. The default dependency is `com.android.tools:r8`, which is
@@ -344,4 +346,10 @@ To enable both:
     }
     ```
 
+[-printmapping]: https://www.guardsquare.com/manual/configuration/usage#printmapping
+[-printseeds]: https://www.guardsquare.com/manual/configuration/usage#printseeds
+[-printusage]: https://www.guardsquare.com/manual/configuration/usage#printusage
+[library-optimization-guidance]: https://developer.android.com/topic/performance/app-optimization/library-optimization
+[R8]: https://r8.googlesource.com/r8
+[ProguardConfigurationParser]: https://r8.googlesource.com/r8/+/refs/tags/9.1.31/src/main/java/com/android/tools/r8/shaking/ProguardConfigurationParser.java
 [ShadowJar.dependencies]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/dependencies.html

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -119,8 +119,8 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
     }
     ```
 
-Shadow writes the final generated ProGuard configuration to
-`build/shadowJar/configuration.txt` by default. Set `configurationFile` to retain it elsewhere.
+R8 writes the collective ProGuard configuration it used to `build/shadowJar/configuration.txt` by default. Shadow
+passes this location to R8 with `--pg-conf-output`. Set `configurationFile` to retain it elsewhere.
 
 R8 also supports ProGuard reporting options such as
 [`-printmapping`](https://www.guardsquare.com/manual/configuration/usage#printmapping),

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -94,6 +94,7 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
           // Optional extra configuration
           proguardRules.add("-keep class com.example.ReflectiveApi { *; }")
           proguardRuleFiles.from(layout.projectDirectory.file("r8-rules.pro"))
+          configurationFile.set(layout.buildDirectory.file("r8/configuration.txt"))
         }
       }
     }
@@ -112,10 +113,14 @@ Shadow also extracts R8 rules published in dependency JARs, for example under `M
           // Optional extra configuration
           proguardRules.add('-keep class com.example.ReflectiveApi { *; }')
           proguardRuleFiles.from(layout.projectDirectory.file('r8-rules.pro'))
+          configurationFile.set(layout.buildDirectory.file('r8/configuration.txt'))
         }
       }
     }
     ```
+
+Shadow writes the final generated ProGuard configuration to
+`build/shadowJar/configuration.txt` by default. Set `configurationFile` to retain it elsewhere.
 
 Shadow resolves R8 from the `shadowR8` configuration. The default dependency is `com.android.tools:r8`, which is
 published by Google Maven rather than Maven Central. Add `google()` to your repositories or override the dependency:

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -405,6 +405,46 @@ class MinimizeTest : BasePluginTest() {
   }
 
   @Test
+  fun minimizeWithR8GeneratesReportsRelativeToConfigurationFile() {
+    writeR8Repository()
+    writeR8ClientAndServerModules(
+      serverShadowBlock =
+        """
+        minimize {
+          r8 {
+            enableObfuscation()
+            configurationFile.set(layout.buildDirectory.file("r8/configuration.txt"))
+            proguardRules.addAll(
+              "-printmapping reports/mapping.txt",
+              "-printseeds reports/seeds.txt",
+              "-printusage reports/usage.txt",
+            )
+          }
+        }
+        """
+          .trimIndent()
+    )
+
+    runWithSuccess(serverShadowJarPath)
+
+    assertThat(path("server/build/r8/configuration.txt").readText())
+      .isEqualTo(
+        """
+        -dontoptimize
+        -keep,includedescriptorclasses class server.Server { *; }
+        -printmapping reports/mapping.txt
+        -printseeds reports/seeds.txt
+        -printusage reports/usage.txt
+        """
+          .trimIndent()
+      )
+    assertThat(path("server/build/r8/reports/mapping.txt").readText()).contains("client.Used")
+    assertThat(path("server/build/r8/reports/seeds.txt").readText()).contains("server.Server")
+    assertThat(path("server/build/r8/reports/usage.txt").readText())
+      .contains("client.Reflective", "client.Unused")
+  }
+
+  @Test
   fun minimizeWithR8UsesClasspathRules() {
     writeR8Repository()
     writeR8ClientAndServerModules(

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -334,13 +334,13 @@ class MinimizeTest : BasePluginTest() {
     assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        # The proguard configuration file for the following section is $inputConfiguration
-        -basedirectory '$configurationDirectory'
-        -dontoptimize
-        -keep,includedescriptorclasses class server.Server { *; }
-        # End of content from $inputConfiguration
-        """
-          .trimIndent() + "\n"
+        |# The proguard configuration file for the following section is $inputConfiguration
+        |-basedirectory '$configurationDirectory'
+        |-dontoptimize
+        |-keep,includedescriptorclasses class server.Server { *; }
+        |# End of content from $inputConfiguration
+        |"""
+          .trimMargin()
       )
   }
 
@@ -404,14 +404,14 @@ class MinimizeTest : BasePluginTest() {
     assertThat(path("server/build/r8/final-configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        # The proguard configuration file for the following section is $inputConfiguration
-        -basedirectory '$configurationDirectory'
-        -dontoptimize
-        -keep,includedescriptorclasses class server.Server { *; }
-        -keep class client.Reflective { *; }
-        # End of content from $inputConfiguration
-        """
-          .trimIndent() + "\n"
+        |# The proguard configuration file for the following section is $inputConfiguration
+        |-basedirectory '$configurationDirectory'
+        |-dontoptimize
+        |-keep,includedescriptorclasses class server.Server { *; }
+        |-keep class client.Reflective { *; }
+        |# End of content from $inputConfiguration
+        |"""
+          .trimMargin()
       )
   }
 
@@ -443,16 +443,16 @@ class MinimizeTest : BasePluginTest() {
     assertThat(path("server/build/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        # The proguard configuration file for the following section is $inputConfiguration
-        -basedirectory '$configurationDirectory'
-        -dontoptimize
-        -keep,includedescriptorclasses class server.Server { *; }
-        -printmapping reports/mapping.txt
-        -printseeds reports/seeds.txt
-        -printusage reports/usage.txt
-        # End of content from $inputConfiguration
-        """
-          .trimIndent() + "\n"
+        |# The proguard configuration file for the following section is $inputConfiguration
+        |-basedirectory '$configurationDirectory'
+        |-dontoptimize
+        |-keep,includedescriptorclasses class server.Server { *; }
+        |-printmapping reports/mapping.txt
+        |-printseeds reports/seeds.txt
+        |-printusage reports/usage.txt
+        |# End of content from $inputConfiguration
+        |"""
+          .trimMargin()
       )
     assertThat(path("server/build/r8/reports/mapping.txt").readText()).contains("client.Used")
     assertThat(path("server/build/r8/reports/seeds.txt").readText()).contains("server.Server")
@@ -495,19 +495,19 @@ class MinimizeTest : BasePluginTest() {
     assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        # The proguard configuration file for the following section is $inputConfiguration
-        -basedirectory '$configurationDirectory'
-        -dontoptimize
-        -keep,includedescriptorclasses class server.Server { *; }
-        # Rules extracted from:
-        # $embeddedRules
-        -keep class client.Reflective { *; }
-        # End of content from $inputConfiguration
-        # The proguard configuration file for the following section is $embeddedRules
-        -keep class client.Reflective { *; }
-        # End of content from $embeddedRules
-        """
-          .trimIndent() + "\n"
+        |# The proguard configuration file for the following section is $inputConfiguration
+        |-basedirectory '$configurationDirectory'
+        |-dontoptimize
+        |-keep,includedescriptorclasses class server.Server { *; }
+        |# Rules extracted from:
+        |# $embeddedRules
+        |-keep class client.Reflective { *; }
+        |# End of content from $inputConfiguration
+        |# The proguard configuration file for the following section is $embeddedRules
+        |-keep class client.Reflective { *; }
+        |# End of content from $embeddedRules
+        |"""
+          .trimMargin()
       )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -364,7 +364,7 @@ class MinimizeTest : BasePluginTest() {
       )
       getContent("META-INF/services/service.Greeter").isEqualTo("service.DefaultGreeter\n")
     }
-    val shadowJarUrl = outputServerShadowedJar.use { it.path.toUri().toURL() }
+    val shadowJarUrl = outputServerShadowedJar.use { it.toUri().toURL() }
     URLClassLoader(arrayOf(shadowJarUrl), null).use { loader ->
       val serviceClass = loader.loadClass("service.Greeter")
       assertThat(ServiceLoader.load(serviceClass, loader).toList()).hasSize(1)
@@ -491,9 +491,8 @@ class MinimizeTest : BasePluginTest() {
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
-    val embeddedRules = outputServerShadowedJar.use {
-      "${it.path.toRealPath()}:META-INF/proguard/client.pro"
-    }
+    val embeddedRules =
+      "${path("server/build/libs/server-1.0-all.jar").toRealPath()}:META-INF/proguard/client.pro"
     assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -329,7 +329,13 @@ class MinimizeTest : BasePluginTest() {
       )
     }
     assertThat(path("server/build/shadowJar/configuration.txt").readText())
-      .contains("-keep,includedescriptorclasses class server.Server { *; }")
+      .isEqualTo(
+        """
+        -dontoptimize
+        -keep,includedescriptorclasses class server.Server { *; }
+        """
+          .trimIndent()
+      )
   }
 
   @Test
@@ -388,7 +394,14 @@ class MinimizeTest : BasePluginTest() {
       )
     }
     assertThat(path("server/build/r8/final-configuration.txt").readText())
-      .contains("-keep class client.Reflective { *; }")
+      .isEqualTo(
+        """
+        -dontoptimize
+        -keep,includedescriptorclasses class server.Server { *; }
+        -keep class client.Reflective { *; }
+        """
+          .trimIndent()
+      )
   }
 
   @Test

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -328,6 +328,8 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    assertThat(path("server/build/shadowJar/configuration.txt").readText())
+      .contains("-keep,includedescriptorclasses class server.Server { *; }")
   }
 
   @Test
@@ -366,6 +368,7 @@ class MinimizeTest : BasePluginTest() {
         minimize {
           r8 {
             proguardRules.add("-keep class client.Reflective { *; }")
+            configurationFile.set(layout.buildDirectory.file("r8/final-configuration.txt"))
           }
         }
         """
@@ -384,6 +387,8 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    assertThat(path("server/build/r8/final-configuration.txt").readText())
+      .contains("-keep class client.Reflective { *; }")
   }
 
   @Test

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -491,7 +491,9 @@ class MinimizeTest : BasePluginTest() {
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
-    val embeddedRules = "${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro"
+    val embeddedRules = outputServerShadowedJar.use {
+      "${it.path.toRealPath()}:META-INF/proguard/client.pro"
+    }
     assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -433,6 +433,17 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    assertThat(path("server/build/shadowJar/configuration.txt").readText())
+      .isEqualTo(
+        """
+        -dontoptimize
+        -keep,includedescriptorclasses class server.Server { *; }
+        # Rules extracted from:
+        # ${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro
+        -keep class client.Reflective { *; }
+        """
+          .trimIndent()
+      )
   }
 
   @Test

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -330,8 +330,8 @@ class MinimizeTest : BasePluginTest() {
       )
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
-    val configurationDirectory = path("server/build/shadowJar").toRealPath()
-    assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
+    val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
+    assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         |# The proguard configuration file for the following section is $inputConfiguration
@@ -490,9 +490,9 @@ class MinimizeTest : BasePluginTest() {
       )
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
-    val configurationDirectory = path("server/build/shadowJar").toRealPath()
+    val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
     val embeddedRules = "${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro"
-    assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
+    assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         |# The proguard configuration file for the following section is $inputConfiguration

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -380,7 +380,7 @@ class MinimizeTest : BasePluginTest() {
         minimize {
           r8 {
             proguardRules.add("-keep class client.Reflective { *; }")
-            configurationFile.set(layout.buildDirectory.file("r8/final-configuration.txt"))
+            configurationFile.set(layout.buildDirectory.file("r8/config/final-configuration.txt"))
           }
         }
         """
@@ -400,8 +400,8 @@ class MinimizeTest : BasePluginTest() {
       )
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
-    val configurationDirectory = path("server/build/r8").toRealPath()
-    assertThat(path("server/build/r8/final-configuration.txt").readText().invariantEolString)
+    val configurationDirectory = path("server/build/r8/config").toRealPath()
+    assertThat(path("server/build/r8/config/final-configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         |# The proguard configuration file for the following section is $inputConfiguration

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -328,13 +328,18 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val configurationDirectory = path("server/build/shadowJar").toRealPath()
     assertThat(path("server/build/shadowJar/configuration.txt").readText())
       .isEqualTo(
         """
+        # The proguard configuration file for the following section is $inputConfiguration
+        -basedirectory '$configurationDirectory'
         -dontoptimize
         -keep,includedescriptorclasses class server.Server { *; }
+        # End of content from $inputConfiguration
         """
-          .trimIndent()
+          .trimIndent() + lineSeparator
       )
   }
 
@@ -393,14 +398,19 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val configurationDirectory = path("server/build/r8").toRealPath()
     assertThat(path("server/build/r8/final-configuration.txt").readText())
       .isEqualTo(
         """
+        # The proguard configuration file for the following section is $inputConfiguration
+        -basedirectory '$configurationDirectory'
         -dontoptimize
         -keep,includedescriptorclasses class server.Server { *; }
         -keep class client.Reflective { *; }
+        # End of content from $inputConfiguration
         """
-          .trimIndent()
+          .trimIndent() + lineSeparator
       )
   }
 
@@ -427,16 +437,21 @@ class MinimizeTest : BasePluginTest() {
 
     runWithSuccess(serverShadowJarPath)
 
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val configurationDirectory = path("server/build/r8").toRealPath()
     assertThat(path("server/build/r8/configuration.txt").readText())
       .isEqualTo(
         """
+        # The proguard configuration file for the following section is $inputConfiguration
+        -basedirectory '$configurationDirectory'
         -dontoptimize
         -keep,includedescriptorclasses class server.Server { *; }
         -printmapping reports/mapping.txt
         -printseeds reports/seeds.txt
         -printusage reports/usage.txt
+        # End of content from $inputConfiguration
         """
-          .trimIndent()
+          .trimIndent() + lineSeparator
       )
     assertThat(path("server/build/r8/reports/mapping.txt").readText()).contains("client.Used")
     assertThat(path("server/build/r8/reports/seeds.txt").readText()).contains("server.Server")
@@ -473,16 +488,25 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val configurationDirectory = path("server/build/shadowJar").toRealPath()
+    val embeddedRules = "${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro"
     assertThat(path("server/build/shadowJar/configuration.txt").readText())
       .isEqualTo(
         """
+        # The proguard configuration file for the following section is $inputConfiguration
+        -basedirectory '$configurationDirectory'
         -dontoptimize
         -keep,includedescriptorclasses class server.Server { *; }
         # Rules extracted from:
-        # ${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro
+        # $embeddedRules
         -keep class client.Reflective { *; }
+        # End of content from $inputConfiguration
+        # The proguard configuration file for the following section is $embeddedRules
+        -keep class client.Reflective { *; }
+        # End of content from $embeddedRules
         """
-          .trimIndent()
+          .trimIndent() + lineSeparator
       )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -10,6 +10,7 @@ import com.github.jengelman.gradle.plugins.shadow.testkit.containsAtLeast
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsNone
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
+import com.github.jengelman.gradle.plugins.shadow.testkit.invariantEolString
 import com.github.jengelman.gradle.plugins.shadow.util.Issue
 import java.net.URLClassLoader
 import java.util.ServiceLoader
@@ -330,7 +331,7 @@ class MinimizeTest : BasePluginTest() {
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar").toRealPath()
-    assertThat(path("server/build/shadowJar/configuration.txt").readText())
+    assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         # The proguard configuration file for the following section is $inputConfiguration
@@ -339,7 +340,7 @@ class MinimizeTest : BasePluginTest() {
         -keep,includedescriptorclasses class server.Server { *; }
         # End of content from $inputConfiguration
         """
-          .trimIndent() + lineSeparator
+          .trimIndent() + "\n"
       )
   }
 
@@ -400,7 +401,7 @@ class MinimizeTest : BasePluginTest() {
     }
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/r8").toRealPath()
-    assertThat(path("server/build/r8/final-configuration.txt").readText())
+    assertThat(path("server/build/r8/final-configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         # The proguard configuration file for the following section is $inputConfiguration
@@ -410,7 +411,7 @@ class MinimizeTest : BasePluginTest() {
         -keep class client.Reflective { *; }
         # End of content from $inputConfiguration
         """
-          .trimIndent() + lineSeparator
+          .trimIndent() + "\n"
       )
   }
 
@@ -439,7 +440,7 @@ class MinimizeTest : BasePluginTest() {
 
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/r8").toRealPath()
-    assertThat(path("server/build/r8/configuration.txt").readText())
+    assertThat(path("server/build/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         # The proguard configuration file for the following section is $inputConfiguration
@@ -451,7 +452,7 @@ class MinimizeTest : BasePluginTest() {
         -printusage reports/usage.txt
         # End of content from $inputConfiguration
         """
-          .trimIndent() + lineSeparator
+          .trimIndent() + "\n"
       )
     assertThat(path("server/build/r8/reports/mapping.txt").readText()).contains("client.Used")
     assertThat(path("server/build/r8/reports/seeds.txt").readText()).contains("server.Server")
@@ -491,7 +492,7 @@ class MinimizeTest : BasePluginTest() {
     val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar").toRealPath()
     val embeddedRules = "${outputServerShadowedJar.path.toRealPath()}:META-INF/proguard/client.pro"
-    assertThat(path("server/build/shadowJar/configuration.txt").readText())
+    assertThat(path("server/build/shadowJar/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
         # The proguard configuration file for the following section is $inputConfiguration
@@ -506,7 +507,7 @@ class MinimizeTest : BasePluginTest() {
         -keep class client.Reflective { *; }
         # End of content from $embeddedRules
         """
-          .trimIndent() + lineSeparator
+          .trimIndent() + "\n"
       )
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -329,16 +329,16 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
-    val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
+    val inputConfigPath = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
+    val outputConfigDir = path("server/build/shadowJar/r8").toRealPath()
     assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        |# The proguard configuration file for the following section is $inputConfiguration
-        |-basedirectory '$configurationDirectory'
+        |# The proguard configuration file for the following section is $inputConfigPath
+        |-basedirectory '$outputConfigDir'
         |-dontoptimize
         |-keep,includedescriptorclasses class server.Server { *; }
-        |# End of content from $inputConfiguration
+        |# End of content from $inputConfigPath
         |"""
           .trimMargin()
       )
@@ -399,17 +399,17 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
-    val configurationDirectory = path("server/build/r8/config").toRealPath()
+    val inputConfigPath = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
+    val outputConfigDir = path("server/build/r8/config").toRealPath()
     assertThat(path("server/build/r8/config/final-configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        |# The proguard configuration file for the following section is $inputConfiguration
-        |-basedirectory '$configurationDirectory'
+        |# The proguard configuration file for the following section is $inputConfigPath
+        |-basedirectory '$outputConfigDir'
         |-dontoptimize
         |-keep,includedescriptorclasses class server.Server { *; }
         |-keep class client.Reflective { *; }
-        |# End of content from $inputConfiguration
+        |# End of content from $inputConfigPath
         |"""
           .trimMargin()
       )
@@ -438,19 +438,19 @@ class MinimizeTest : BasePluginTest() {
 
     runWithSuccess(serverShadowJarPath)
 
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
-    val configurationDirectory = path("server/build/r8").toRealPath()
+    val inputConfigPath = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
+    val outputConfigDir = path("server/build/r8").toRealPath()
     assertThat(path("server/build/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        |# The proguard configuration file for the following section is $inputConfiguration
-        |-basedirectory '$configurationDirectory'
+        |# The proguard configuration file for the following section is $inputConfigPath
+        |-basedirectory '$outputConfigDir'
         |-dontoptimize
         |-keep,includedescriptorclasses class server.Server { *; }
         |-printmapping reports/mapping.txt
         |-printseeds reports/seeds.txt
         |-printusage reports/usage.txt
-        |# End of content from $inputConfiguration
+        |# End of content from $inputConfigPath
         |"""
           .trimMargin()
       )
@@ -489,24 +489,24 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
-    val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
-    val embeddedRules =
+    val inputConfigPath = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
+    val outputConfigDir = path("server/build/shadowJar/r8").toRealPath()
+    val embeddedConfigPath =
       "${path("server/build/libs/server-1.0-all.jar").toRealPath()}:META-INF/proguard/client.pro"
     assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
         """
-        |# The proguard configuration file for the following section is $inputConfiguration
-        |-basedirectory '$configurationDirectory'
+        |# The proguard configuration file for the following section is $inputConfigPath
+        |-basedirectory '$outputConfigDir'
         |-dontoptimize
         |-keep,includedescriptorclasses class server.Server { *; }
         |# Rules extracted from:
-        |# $embeddedRules
+        |# $embeddedConfigPath
         |-keep class client.Reflective { *; }
-        |# End of content from $inputConfiguration
-        |# The proguard configuration file for the following section is $embeddedRules
+        |# End of content from $inputConfigPath
+        |# The proguard configuration file for the following section is $embeddedConfigPath
         |-keep class client.Reflective { *; }
-        |# End of content from $embeddedRules
+        |# End of content from $embeddedConfigPath
         |"""
           .trimMargin()
       )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/MinimizeTest.kt
@@ -329,7 +329,7 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
     assertThat(path("server/build/shadowJar/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
@@ -399,7 +399,7 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
     val configurationDirectory = path("server/build/r8/config").toRealPath()
     assertThat(path("server/build/r8/config/final-configuration.txt").readText().invariantEolString)
       .isEqualTo(
@@ -438,7 +438,7 @@ class MinimizeTest : BasePluginTest() {
 
     runWithSuccess(serverShadowJarPath)
 
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
     val configurationDirectory = path("server/build/r8").toRealPath()
     assertThat(path("server/build/r8/configuration.txt").readText().invariantEolString)
       .isEqualTo(
@@ -489,7 +489,7 @@ class MinimizeTest : BasePluginTest() {
         *manifestEntries,
       )
     }
-    val inputConfiguration = path("server/build/tmp/shadowJar/r8/configuration.pro").toRealPath()
+    val inputConfiguration = path("server/build/tmp/shadowJar/r8/rules.pro").toRealPath()
     val configurationDirectory = path("server/build/shadowJar/r8").toRealPath()
     val embeddedRules =
       "${path("server/build/libs/server-1.0-all.jar").toRealPath()}:META-INF/proguard/client.pro"

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
@@ -31,7 +31,7 @@ constructor(
   override val configurationFile: RegularFileProperty =
     objectFactory
       .fileProperty()
-      .convention(layout.buildDirectory.file("shadowJar/configuration.txt"))
+      .convention(layout.buildDirectory.file("shadowJar/r8/configuration.txt"))
 
   override fun enableObfuscation() {
     defaultArgs.set(emptyList())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
@@ -2,13 +2,20 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.R8Spec
 import javax.inject.Inject
+import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
-internal open class DefaultR8Spec @Inject constructor(objectFactory: ObjectFactory) : R8Spec {
+internal open class DefaultR8Spec
+@Inject
+constructor(
+  project: Project,
+  objectFactory: ObjectFactory,
+) : R8Spec {
   private val defaultArgs: ListProperty<String> = objectFactory.listProperty(DEFAULT_ARGS)
 
   @get:Input val obfuscationEnabled: Property<Boolean> = objectFactory.property(false)
@@ -20,6 +27,11 @@ internal open class DefaultR8Spec @Inject constructor(objectFactory: ObjectFacto
   override val proguardRules: ListProperty<String> = objectFactory.listProperty()
 
   override val proguardRuleFiles: ConfigurableFileCollection = objectFactory.fileCollection()
+
+  override val configurationFile: RegularFileProperty =
+    objectFactory
+      .fileProperty()
+      .convention(project.layout.buildDirectory.file("shadowJar/configuration.txt"))
 
   override fun enableObfuscation() {
     defaultArgs.set(emptyList())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
@@ -2,8 +2,8 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.R8Spec
 import javax.inject.Inject
-import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.Input
 internal open class DefaultR8Spec
 @Inject
 constructor(
-  project: Project,
+  layout: ProjectLayout,
   objectFactory: ObjectFactory,
 ) : R8Spec {
   private val defaultArgs: ListProperty<String> = objectFactory.listProperty(DEFAULT_ARGS)
@@ -31,7 +31,7 @@ constructor(
   override val configurationFile: RegularFileProperty =
     objectFactory
       .fileProperty()
-      .convention(project.layout.buildDirectory.file("shadowJar/configuration.txt"))
+      .convention(layout.buildDirectory.file("shadowJar/configuration.txt"))
 
   override fun enableObfuscation() {
     defaultArgs.set(emptyList())

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -55,7 +55,7 @@ internal class R8Minimizer(
 
     val r8Dir = temporaryDir.resolve("r8").also { it.mkdirs() }
     val extractedRulesFile = r8Dir.resolve("classpath-rules.pro")
-    val inputConfigurationFile = r8Dir.resolve("configuration.pro")
+    val rulesFile = r8Dir.resolve("configuration.pro")
     val configurationFile = r8Spec.configurationFile.get().asFile
     val r8Output = r8Dir.resolve("output.jar")
     val normalizedOutput = r8Dir.resolve("normalized-output.jar")
@@ -70,7 +70,7 @@ internal class R8Minimizer(
 
     val r8Args = r8Spec.args.get()
     configurationFile.parentFile.mkdirs()
-    inputConfigurationFile.writeText(
+    rulesFile.writeText(
       buildList {
           add("-basedirectory ${configurationFile.parentFile.asProguardPath()}")
           addAll(createRules(inputJar, r8Args, extractedRulesFile))
@@ -83,7 +83,7 @@ internal class R8Minimizer(
       add("--output")
       add(r8Output.absolutePath)
       add("--pg-conf")
-      add(inputConfigurationFile.absolutePath)
+      add(rulesFile.absolutePath)
       add("--pg-conf-output")
       add(configurationFile.absolutePath)
       add("--lib")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -69,12 +69,13 @@ internal class R8Minimizer(
     extractClasspathRules(inputJar, extractedRulesFile, launcher)
 
     val r8Args = r8Spec.args.get()
-    configurationFile.parentFile.mkdirs()
     rulesFile.writeText(
-      buildList {
-          add("-basedirectory ${configurationFile.parentFile.asProguardPath()}")
-          addAll(createRules(inputJar, r8Args, extractedRulesFile))
-        }
+      createRules(
+          baseDirectory = configurationFile.parentFile.apply { mkdirs() },
+          inputJar = inputJar,
+          r8Args = r8Args,
+          extractedRulesFile = extractedRulesFile,
+        )
         .joinToString(System.lineSeparator())
     )
 
@@ -133,11 +134,13 @@ internal class R8Minimizer(
   }
 
   private fun createRules(
+    baseDirectory: File,
     inputJar: File,
     r8Args: List<String>,
     extractedRulesFile: File,
   ): List<String> {
     return buildList {
+      add(baseDirectory.toBaseDirectoryRule())
       if (shouldDisableOptimization(r8Args)) {
         add(DefaultR8Spec.DONT_OPTIMIZE_RULE)
       }
@@ -249,8 +252,11 @@ internal class R8Minimizer(
       .replace('/', '.')
   }
 
-  private fun File.asProguardPath(): String {
-    return "'${absolutePath.replace("'", "\\'")}'"
+  private fun File.toBaseDirectoryRule(): String {
+    // Preserve Windows separators: escaping backslashes changes the paths R8 writes to the
+    // collective configuration produced through --pg-conf-output.
+    val normalizedPath = absolutePath.replace("'", "\\'")
+    return "-basedirectory '$normalizedPath'"
   }
 
   private fun File.classNames(): Sequence<String> {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -55,7 +55,7 @@ internal class R8Minimizer(
 
     val r8Dir = temporaryDir.resolve("r8").also { it.mkdirs() }
     val extractedRulesFile = r8Dir.resolve("classpath-rules.pro")
-    val rulesFile = r8Dir.resolve("configuration.pro")
+    val rulesFile = r8Dir.resolve("rules.pro")
     val configurationFile = r8Spec.configurationFile.get().asFile
     val r8Output = r8Dir.resolve("output.jar")
     val normalizedOutput = r8Dir.resolve("normalized-output.jar")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -250,7 +250,7 @@ internal class R8Minimizer(
   }
 
   private fun File.asProguardPath(): String {
-    return "'${absolutePath.replace("\\", "\\\\").replace("'", "\\'")}'"
+    return "'${absolutePath.replace("'", "\\'")}'"
   }
 
   private fun File.classNames(): Sequence<String> {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -55,7 +55,7 @@ internal class R8Minimizer(
 
     val r8Dir = temporaryDir.resolve("r8").also { it.mkdirs() }
     val extractedRulesFile = r8Dir.resolve("classpath-rules.pro")
-    val rulesFile = r8Dir.resolve("rules.pro")
+    val configurationFile = r8Spec.configurationFile.get().asFile
     val r8Output = r8Dir.resolve("output.jar")
     val normalizedOutput = r8Dir.resolve("normalized-output.jar")
     val launcher = javaLauncher.orNull
@@ -68,7 +68,8 @@ internal class R8Minimizer(
     extractClasspathRules(inputJar, extractedRulesFile, launcher)
 
     val r8Args = r8Spec.args.get()
-    rulesFile.writeText(
+    configurationFile.parentFile.mkdirs()
+    configurationFile.writeText(
       createRules(inputJar, r8Args, extractedRulesFile).joinToString(System.lineSeparator())
     )
 
@@ -77,7 +78,7 @@ internal class R8Minimizer(
       add("--output")
       add(r8Output.absolutePath)
       add("--pg-conf")
-      add(rulesFile.absolutePath)
+      add(configurationFile.absolutePath)
       add("--lib")
       add(javaHome)
       addAll(r8Args)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -55,6 +55,7 @@ internal class R8Minimizer(
 
     val r8Dir = temporaryDir.resolve("r8").also { it.mkdirs() }
     val extractedRulesFile = r8Dir.resolve("classpath-rules.pro")
+    val inputConfigurationFile = r8Dir.resolve("configuration.pro")
     val configurationFile = r8Spec.configurationFile.get().asFile
     val r8Output = r8Dir.resolve("output.jar")
     val normalizedOutput = r8Dir.resolve("normalized-output.jar")
@@ -69,8 +70,12 @@ internal class R8Minimizer(
 
     val r8Args = r8Spec.args.get()
     configurationFile.parentFile.mkdirs()
-    configurationFile.writeText(
-      createRules(inputJar, r8Args, extractedRulesFile).joinToString(System.lineSeparator())
+    inputConfigurationFile.writeText(
+      buildList {
+          add("-basedirectory ${configurationFile.parentFile.asProguardPath()}")
+          addAll(createRules(inputJar, r8Args, extractedRulesFile))
+        }
+        .joinToString(System.lineSeparator())
     )
 
     val arguments = buildList {
@@ -78,6 +83,8 @@ internal class R8Minimizer(
       add("--output")
       add(r8Output.absolutePath)
       add("--pg-conf")
+      add(inputConfigurationFile.absolutePath)
+      add("--pg-conf-output")
       add(configurationFile.absolutePath)
       add("--lib")
       add(javaHome)
@@ -240,6 +247,10 @@ internal class R8Minimizer(
       .replace(File.separatorChar, '/')
       .removeSuffix(".class")
       .replace('/', '.')
+  }
+
+  private fun File.asProguardPath(): String {
+    return "'${absolutePath.replace("\\", "\\\\").replace("'", "\\'")}'"
   }
 
   private fun File.classNames(): Sequence<String> {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -2,9 +2,11 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
@@ -42,6 +44,13 @@ public interface R8Spec {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   public val proguardRuleFiles: ConfigurableFileCollection
+
+  /**
+   * The final ProGuard configuration generated for R8.
+   *
+   * Defaults to `build/shadowJar/configuration.txt`.
+   */
+  @get:OutputFile public val configurationFile: RegularFileProperty
 
   /**
    * Enable R8 name obfuscation while keeping Shadow's default no-optimization behavior.

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -48,7 +48,7 @@ public interface R8Spec {
   /**
    * The collective ProGuard configuration output by R8.
    *
-   * Defaults to `build/shadowJar/configuration.txt`.
+   * Defaults to `build/shadowJar/r8/configuration.txt`.
    */
   @get:OutputFile public val configurationFile: RegularFileProperty
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -46,7 +46,7 @@ public interface R8Spec {
   public val proguardRuleFiles: ConfigurableFileCollection
 
   /**
-   * The final ProGuard configuration generated for R8.
+   * The collective ProGuard configuration output by R8.
    *
    * Defaults to `build/shadowJar/configuration.txt`.
    */

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
@@ -41,6 +41,8 @@ class MinimizeSpecsTest {
       assertThat(optimizationEnabled.get()).isFalse()
       assertThat(proguardRules.get()).isEmpty()
       assertThat(proguardRuleFiles.files).isEmpty()
+      assertThat(configurationFile.get().asFile)
+        .isEqualTo(project.layout.buildDirectory.file("shadowJar/configuration.txt").get().asFile)
     }
 
   @Test

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
@@ -42,7 +42,9 @@ class MinimizeSpecsTest {
       assertThat(proguardRules.get()).isEmpty()
       assertThat(proguardRuleFiles.files).isEmpty()
       assertThat(configurationFile.get().asFile)
-        .isEqualTo(project.layout.buildDirectory.file("shadowJar/configuration.txt").get().asFile)
+        .isEqualTo(
+          project.layout.buildDirectory.file("shadowJar/r8/configuration.txt").get().asFile
+        )
     }
 
   @Test


### PR DESCRIPTION
Closes #2128.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
