### PR TITLE
Remove redundant id assignment in BasePluginTest

### DIFF
--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/BasePluginTest.kt
@@ -354,7 +354,6 @@ abstract class BasePluginTest {
         gradlePlugin {
           plugins {
             create('my.plugin') {
-              id = 'my.plugin'
               implementationClass = 'my.plugin.MyPlugin'
             }
           }


### PR DESCRIPTION
Follow up #2114.

https://docs.gradle.org/9.4.0/release-notes.html#default-plugin-ids
