### PR TITLE
Deprecate `DontIncludeResourceTransformer` and `IncludeResourceTransformer`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -18,6 +18,8 @@
   Calling `proguardRules` and `proguardRuleFiles` instead. The properties will be removed in Shadow 10.
 - Deprecate `ShadowJar.minimizeJar`. ([#2124](https://github.com/GradleUp/shadow/pull/2124))  
   Calling `ShadowJar.minimize()` explicitly instead. The property will be made non-public in Shadow 10.
+- Deprecate `DontIncludeResourceTransformer` and `IncludeResourceTransformer`. ([#2143](https://github.com/GradleUp/shadow/pull/2143))  
+  Use `ShadowJar.exclude` or `ShadowJar.from` instead. The classes will be removed in Shadow 10.
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -156,6 +156,7 @@ class TransformersTest : BaseTransformerTest() {
   fun includeResource() {
     val foo = path("foo").apply { writeText("foo") }
     projectScript.appendText(
+      @Suppress("DEPRECATION")
       transform<IncludeResourceTransformer>(
         transformerBlock =
           """
@@ -181,6 +182,7 @@ class TransformersTest : BaseTransformerTest() {
       insert("bar", "foo")
     }
     projectScript.appendText(
+      @Suppress("DEPRECATION")
       transform<DontIncludeResourceTransformer>(
         dependenciesBlock = implementationFiles(one),
         transformerBlock = "resource = 'foo'",

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
@@ -18,6 +18,10 @@ import org.gradle.api.tasks.Input
  *
  * @author John Engelman
  */
+@Deprecated(
+  message = "Use `ShadowJar.exclude` instead. This will be removed in Shadow 10.",
+  replaceWith = ReplaceWith("exclude"),
+)
 @CacheableTransformer
 public open class DontIncludeResourceTransformer
 @Inject

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
@@ -23,6 +23,10 @@ import org.gradle.api.tasks.PathSensitivity
  *
  * @author John Engelman
  */
+@Deprecated(
+  message = "Use `ShadowJar.from` instead. This will be removed in Shadow 10.",
+  replaceWith = ReplaceWith("from"),
+)
 @CacheableTransformer
 public open class IncludeResourceTransformer
 @Inject


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
