### PR TITLE
Remove `Serializable` from `DependencyFilter`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -160,7 +160,7 @@ public class com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocat
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter : java/io/Serializable {
+public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter {
 	public abstract fun dependency (Ljava/lang/Object;)Lorg/gradle/api/specs/Spec;
 	public abstract fun exclude (Lorg/gradle/api/specs/Spec;)V
 	public abstract fun include (Lorg/gradle/api/specs/Spec;)V

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -11,6 +11,7 @@
 
 - Bump min Gradle requirement to 9.4.0. ([#2114](https://github.com/GradleUp/shadow/pull/2114))
 - Remove runtime dependencies on Commons Codec and Commons IO by using JDK APIs. ([#2136](https://github.com/GradleUp/shadow/pull/2136))
+- **POTENTIALLY BREAKING:** Remove `Serializable` from `DependencyFilter`.
 
 ### Deprecated
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -11,7 +11,7 @@
 
 - Bump min Gradle requirement to 9.4.0. ([#2114](https://github.com/GradleUp/shadow/pull/2114))
 - Remove runtime dependencies on Commons Codec and Commons IO by using JDK APIs. ([#2136](https://github.com/GradleUp/shadow/pull/2136))
-- **POTENTIALLY BREAKING:** Remove `Serializable` from `DependencyFilter`.
+- **POTENTIALLY BREAKING:** Remove `Serializable` from `DependencyFilter`. ([#2144](https://github.com/GradleUp/shadow/pull/2144))
 
 ### Deprecated
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -4,7 +4,6 @@ import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import com.github.jengelman.gradle.plugins.shadow.internal.MinimizeDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
@@ -71,32 +70,6 @@ class CachingTest : BasePluginTest() {
     assertThat(jarPath("build/libs/foo-1.0-all.jar")).useAll {
       containsOnly(*entriesInAB, *manifestEntries)
     }
-  }
-
-  @Test
-  fun dependencyFilterWithSameResultChanged() {
-    projectScript.appendText(
-      """
-      dependencies {
-        implementation 'my:d:1.0'
-      }
-      """
-        .trimIndent() + lineSeparator
-    )
-    assertCompositeExecutions {
-      containsOnly("c.properties", "d.properties", *manifestEntries)
-    }
-
-    projectScript.appendText(
-      """
-        $shadowJarTask {
-          dependencyFilter = new ${MinimizeDependencyFilter::class.java.name}(project)
-        }
-      """
-        .trimIndent()
-    )
-
-    assertRunWithResult(TaskOutcome.UP_TO_DATE)
   }
 
   @Test

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -74,7 +74,7 @@ class CachingTest : BasePluginTest() {
   }
 
   @Test
-  fun dependencyFilterChanged() {
+  fun dependencyFilterWithSameResultChanged() {
     projectScript.appendText(
       """
       dependencies {
@@ -83,11 +83,9 @@ class CachingTest : BasePluginTest() {
       """
         .trimIndent() + lineSeparator
     )
-    val assertions = {
-      assertCompositeExecutions { containsOnly("c.properties", "d.properties", *manifestEntries) }
+    assertCompositeExecutions {
+      containsOnly("c.properties", "d.properties", *manifestEntries)
     }
-
-    assertions()
 
     projectScript.appendText(
       """
@@ -98,7 +96,7 @@ class CachingTest : BasePluginTest() {
         .trimIndent()
     )
 
-    assertions()
+    assertRunWithResult(TaskOutcome.UP_TO_DATE)
   }
 
   @Test

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -10,7 +10,6 @@ import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
-import org.gradle.api.tasks.Internal
 
 @ShadowDsl
 public interface DependencyFilter {
@@ -37,12 +36,8 @@ public interface DependencyFilter {
 
   public abstract class AbstractDependencyFilter(
     @Transient private val project: Project,
-    @get:Internal
-    @Transient
-    protected val includeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
-    @get:Internal
-    @Transient
-    protected val excludeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
+    @Transient protected val includeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
+    @Transient protected val excludeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
   ) : DependencyFilter {
 
     protected abstract fun resolve(

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -1,7 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowDsl
-import java.io.Serializable
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
@@ -14,9 +13,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Internal
 
 @ShadowDsl
-public interface DependencyFilter :
-  // DependencyFilter is used as Gradle Input in ShadowJar, so it must be Serializable.
-  Serializable {
+public interface DependencyFilter {
   /** Resolve a [configuration] against the [include]/[exclude] rules in the filter. */
   public fun resolve(configuration: Configuration): FileCollection
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/DependencyFilter.kt
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Internal
 
 @ShadowDsl
 public interface DependencyFilter {
@@ -36,8 +37,12 @@ public interface DependencyFilter {
 
   public abstract class AbstractDependencyFilter(
     @Transient private val project: Project,
-    @Transient protected val includeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
-    @Transient protected val excludeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
+    @get:Internal
+    @Transient
+    protected val includeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
+    @get:Internal
+    @Transient
+    protected val excludeSpecs: MutableList<Spec<ResolvedDependency>> = mutableListOf(),
   ) : DependencyFilter {
 
     protected abstract fun resolve(

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -177,8 +177,7 @@ public abstract class ShadowJar : Jar() {
   @get:Classpath
   public open val configurations: SetProperty<Configuration> = objectFactory.setProperty()
 
-  // The resolved result is tracked by includedDependencies.
-  @get:Internal
+  @get:Internal // The resolved result is tracked by includedDependencies.
   public open val dependencyFilter: Property<DependencyFilter> =
     objectFactory.property(DefaultDependencyFilter(project))
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -177,7 +177,8 @@ public abstract class ShadowJar : Jar() {
   @get:Classpath
   public open val configurations: SetProperty<Configuration> = objectFactory.setProperty()
 
-  @get:Input
+  // The resolved result is tracked by includedDependencies.
+  @get:Internal
   public open val dependencyFilter: Property<DependencyFilter> =
     objectFactory.property(DefaultDependencyFilter(project))
 


### PR DESCRIPTION
Reverts #1212.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
