### PR TITLE
Note changelog for R8 updates

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -12,6 +12,7 @@
 - Bump min Gradle requirement to 9.4.0. ([#2114](https://github.com/GradleUp/shadow/pull/2114))
 - Remove runtime dependencies on Commons Codec and Commons IO by using JDK APIs. ([#2136](https://github.com/GradleUp/shadow/pull/2136))
 - **POTENTIALLY BREAKING:** Remove `Serializable` from `DependencyFilter`. ([#2144](https://github.com/GradleUp/shadow/pull/2144))
+- Bump default R8 from `9.1.31` to `9.2.23`. ([#2157](https://github.com/GradleUp/shadow/pull/2157))
 
 ### Deprecated
 


### PR DESCRIPTION
Refs #2157.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
