### PR TITLE
Cache dynamic versions in documentation tests

### DIFF
--- a/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/snippet/SnippetExecutable.kt
+++ b/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/snippet/SnippetExecutable.kt
@@ -40,6 +40,12 @@ sealed class SnippetExecutable : Executable {
       .resolve("settings.gradle")
       .writeText(
         """
+        |gradle.beforeProject {
+        |  buildscript.configurations.configureEach {
+        |    // Snippet version placeholders resolve to '+', so avoid frequent remote version checks.
+        |    resolutionStrategy.cacheDynamicVersionsFor(30, java.util.concurrent.TimeUnit.DAYS)
+        |  }
+        |}
         |dependencyResolutionManagement {
         |  repositories {
         |    mavenLocal()

--- a/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/snippet/SnippetExecutable.kt
+++ b/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/snippet/SnippetExecutable.kt
@@ -40,9 +40,12 @@ sealed class SnippetExecutable : Executable {
       .resolve("settings.gradle")
       .writeText(
         """
-        |gradle.beforeProject {
-        |  buildscript.configurations.configureEach {
-        |    // Snippet version placeholders resolve to '+', so avoid frequent remote version checks.
+        |gradle.beforeProject { p ->
+        |  // Snippet version placeholders resolve to '+', so avoid frequent remote version checks.
+        |  p.buildscript.configurations.configureEach {
+        |    resolutionStrategy.cacheDynamicVersionsFor(30, java.util.concurrent.TimeUnit.DAYS)
+        |  }
+        |  p.configurations.configureEach {
         |    resolutionStrategy.cacheDynamicVersionsFor(30, java.util.concurrent.TimeUnit.DAYS)
         |  }
         |}


### PR DESCRIPTION
> Gradle keeps a cache of dynamic version => resolved version (ie 2.+ => 2.3). By default, these cached values are kept for 24 hours, after which the cached entry is expired and the dynamic version is resolved again.

https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts/-resolution-strategy/cache-dynamic-versions-for.html


Follow up #2155.