### PR TITLE
Deprecate `TransformerContext.Builder`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -23,6 +23,8 @@
   Calling `ShadowJar.minimize()` explicitly instead. The property will be made non-public in Shadow 10.
 - Deprecate `DontIncludeResourceTransformer` and `IncludeResourceTransformer`. ([#2143](https://github.com/GradleUp/shadow/pull/2143))  
   Use `ShadowJar.exclude` or `ShadowJar.from` instead. The classes will be removed in Shadow 10.
+- Deprecate `TransformerContext.Builder`. ([#2184](https://github.com/GradleUp/shadow/pull/2184))  
+  Use `TransformerContext` constructor instead. The classes will be removed in Shadow 10.
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -24,7 +24,7 @@
 - Deprecate `DontIncludeResourceTransformer` and `IncludeResourceTransformer`. ([#2143](https://github.com/GradleUp/shadow/pull/2143))  
   Use `ShadowJar.exclude` or `ShadowJar.from` instead. The classes will be removed in Shadow 10.
 - Deprecate `TransformerContext.Builder`. ([#2184](https://github.com/GradleUp/shadow/pull/2184))  
-  Use `TransformerContext` constructor instead. The classes will be removed in Shadow 10.
+  Use `TransformerContext` constructor instead. The Builder API will be removed in Shadow 10.
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext.kt
@@ -3,6 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import java.io.InputStream
 
+@Suppress("DEPRECATION")
 public data class TransformerContext
 @JvmOverloads
 constructor(
@@ -10,6 +11,10 @@ constructor(
   val inputStream: InputStream,
   val relocators: Set<Relocator> = emptySet(),
 ) {
+  @Deprecated(
+    message = "Use `TransformerContext` constructor instead. Will be removed in Shadow 10.",
+    replaceWith = ReplaceWith("TransformerContext"),
+  )
   public class Builder {
     private var path = ""
     private var inputStream: InputStream? = null
@@ -34,6 +39,11 @@ constructor(
   }
 
   public companion object {
-    @JvmStatic public fun builder(): Builder = Builder()
+    @Deprecated(
+      message = "Use `TransformerContext` constructor instead. Will be removed in Shadow 10.",
+      replaceWith = ReplaceWith("TransformerContext"),
+    )
+    @JvmStatic
+    public fun builder(): Builder = Builder()
   }
 }


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
