### PR TITLE
Run documentation tests in parallel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,9 +151,13 @@ testing.suites {
     targets.configureEach {
       testTask {
         systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+        systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
         systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
+        // Each snippet runs a nested Gradle build. Two-way parallelism performed better than
+        // four-way by avoiding excessive CPU, memory, and disk contention.
         systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", "2")
         systemProperty("junit.jupiter.execution.parallel.config.fixed.max-pool-size", "2")
+
         inputs.files(
           fileTree(docsDir) {
             // Changelog file doesn't contain code snippet to run.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,8 +152,8 @@ testing.suites {
       testTask {
         systemProperty("junit.jupiter.execution.parallel.enabled", "true")
         systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
-        systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", "4")
-        systemProperty("junit.jupiter.execution.parallel.config.fixed.max-pool-size", "4")
+        systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", "2")
+        systemProperty("junit.jupiter.execution.parallel.config.fixed.max-pool-size", "2")
         inputs.files(
           fileTree(docsDir) {
             // Changelog file doesn't contain code snippet to run.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,10 @@ testing.suites {
   register<JvmTestSuite>("documentTest") {
     targets.configureEach {
       testTask {
+        systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+        systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
+        systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", "4")
+        systemProperty("junit.jupiter.execution.parallel.config.fixed.max-pool-size", "4")
         inputs.files(
           fileTree(docsDir) {
             // Changelog file doesn't contain code snippet to run.

--- a/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/DocCodeSnippetTest.kt
+++ b/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/DocCodeSnippetTest.kt
@@ -7,13 +7,10 @@ import kotlin.io.path.createDirectory
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.io.TempDir
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 
 class DocCodeSnippetTest {
 
   @TestFactory
-  @Execution(ExecutionMode.CONCURRENT)
   fun provideDynamicTests(@TempDir root: Path): List<DynamicTest> {
     val langExecutables = DslLang.entries.map { executor -> CodeSnippetExtractor.extract(executor) }
 

--- a/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/DocCodeSnippetTest.kt
+++ b/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/DocCodeSnippetTest.kt
@@ -7,10 +7,13 @@ import kotlin.io.path.createDirectory
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 
 class DocCodeSnippetTest {
 
   @TestFactory
+  @Execution(ExecutionMode.CONCURRENT)
   fun provideDynamicTests(@TempDir root: Path): List<DynamicTest> {
     val langExecutables = DslLang.entries.map { executor -> CodeSnippetExtractor.extract(executor) }
 


### PR DESCRIPTION
## Summary

- enable JUnit Jupiter parallel execution for documentation snippet tests
- run generated snippet tests with fixed two-way parallelism
- cap the pool at two threads to avoid oversubscription

Each documentation snippet launches a nested Gradle build. Local A/B testing showed that two-way parallelism performs substantially better than four-way parallelism because it avoids excessive CPU, memory, and disk contention.

## Validation

- `./gradlew spotlessCheck --non-interactive`
- `./gradlew documentTest --rerun-tasks --non-interactive`
  - 170 tests passed
  - 64.1 s JUnit suite time
  - 127.6 s cumulative test-case time
  - 1.99 overlap ratio, confirming two-way execution
  - 68.7 s total Gradle wall-clock time

## Performance comparison

| Parallelism | Gradle wall-clock time | JUnit suite time | Cumulative test-case time |
| --- | ---: | ---: | ---: |
| 2 | 73.7 s | 64.7 s | 128.9 s |
| 4 | 145.2 s | 140.3 s | 548.9 s |

The final configuration was rerun after replacing the method-level `@Execution` annotation with `junit.jupiter.execution.parallel.mode.default=concurrent`; that run completed in 68.7 seconds with all 170 tests passing.

https://docs.junit.org/6.1.2/writing-tests/parallel-execution.html