### PR TITLE
Deprecate InheritManifest, minimizeJar, and TransformerContext.Builder

### DIFF
--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -26,6 +26,7 @@
 
 - Deprecate `InheritManifest`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
 - Deprecate `minimizeJar` property. ([#2124](https://github.com/GradleUp/shadow/pull/2124))
+- Deprecate `TransformerContext.Builder`. ([#2184](https://github.com/GradleUp/shadow/pull/2184))
 
 ## [v8.3.11] (2026-05-28)
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -25,6 +25,7 @@
 **Deprecated**
 
 - Deprecate `InheritManifest`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
+- Deprecate `minimizeJar` property. ([#2124](https://github.com/GradleUp/shadow/pull/2124))
 
 ## [v8.3.11] (2026-05-28)
 

--- a/src/docs/changes/README.md
+++ b/src/docs/changes/README.md
@@ -22,6 +22,10 @@
 - Fix relocation exclusion for file patterns like `kotlin/kotlin.kotlin_builtins`. ([#1313](https://github.com/GradleUp/shadow/pull/1313))
 
 
+**Deprecated**
+
+- Deprecate `InheritManifest`. ([#1722](https://github.com/GradleUp/shadow/pull/1722))
+
 ## [v8.3.11] (2026-05-28)
 
 > [!WARNING]

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/DefaultInheritManifest.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/DefaultInheritManifest.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.java.archives.ManifestMergeSpec
 import org.gradle.api.java.archives.internal.DefaultManifest
 import org.gradle.api.java.archives.internal.DefaultManifestMergeSpec
 
+@SuppressWarnings("deprecation")
 class DefaultInheritManifest implements InheritManifest {
 
     private List<DefaultManifestMergeSpec> inheritMergeSpecs = []

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.groovy
@@ -3,7 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 import org.gradle.api.java.archives.Manifest
 
 /**
- * @deprecated inheritFrom should be replaced by from.
+ * @deprecated Use {@link Manifest#from(Object...)} on the standard Gradle {@link Manifest} instead.
  */
 @Deprecated
 interface InheritManifest extends Manifest {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/InheritManifest.groovy
@@ -2,6 +2,10 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import org.gradle.api.java.archives.Manifest
 
+/**
+ * @deprecated inheritFrom should be replaced by from.
+ */
+@Deprecated
 interface InheritManifest extends Manifest {
 
     InheritManifest inheritFrom(Object... inheritPaths)

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -81,7 +81,6 @@ public abstract class ShadowJar extends Jar implements ShadowSpec {
         relocators = new ArrayList<>();
         configurations = new ArrayList<>();
 
-        this.getInputs().property("minimize", (Callable<Boolean>) () -> minimizeJar);
         this.getOutputs().doNotCacheIf("Has one or more transforms or relocators that are not cacheable", task -> {
             for (Transformer transformer : transformers) {
                 if (!isCacheableTransform(transformer.getClass())) {
@@ -475,5 +474,22 @@ public abstract class ShadowJar extends Jar implements ShadowSpec {
 
     public void setRelocationPrefix(String relocationPrefix) {
         this.relocationPrefix = relocationPrefix;
+    }
+
+    /**
+     * @deprecated Use {@link #minimize()} instead.
+     */
+    @Deprecated
+    @Input
+    public boolean getMinimizeJar() {
+        return minimizeJar;
+    }
+
+    /**
+     * @deprecated Use {@link #minimize()} instead.
+     */
+    @Deprecated
+    public void setMinimizeJar(boolean minimizeJar) {
+        this.minimizeJar = minimizeJar;
     }
 }

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.java
@@ -477,7 +477,8 @@ public abstract class ShadowJar extends Jar implements ShadowSpec {
     }
 
     /**
-     * @deprecated Use {@link #minimize()} instead.
+     * @deprecated This legacy boolean property is deprecated. Use {@link #minimize()} to enable minimization;
+     * omitting the call keeps minimization disabled.
      */
     @Deprecated
     @Input
@@ -486,7 +487,8 @@ public abstract class ShadowJar extends Jar implements ShadowSpec {
     }
 
     /**
-     * @deprecated Use {@link #minimize()} instead.
+     * @deprecated This legacy boolean property is deprecated. Use {@link #minimize()} when enabling minimization;
+     * setting {@code false} is equivalent to not calling {@code minimize()}.
      */
     @Deprecated
     public void setMinimizeJar(boolean minimizeJar) {

--- a/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext.groovy
+++ b/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext.groovy
@@ -4,17 +4,42 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowStats
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction
 import groovy.transform.Canonical
-import groovy.transform.builder.Builder
-
 
 @Canonical
-@Builder
 class TransformerContext {
 
     String path
     InputStream is
     List<Relocator> relocators
     ShadowStats stats
+
+    /**
+     * @deprecated Use TransformerContext constructor instead.
+     */
+    @Deprecated
+    static class Builder {
+        private String path
+        private InputStream is
+        private List<Relocator> relocators
+        private ShadowStats stats
+
+        Builder path(String path) { this.path = path; return this }
+        Builder is(InputStream is) { this.is = is; return this }
+        Builder relocators(List<Relocator> relocators) { this.relocators = relocators; return this }
+        Builder stats(ShadowStats stats) { this.stats = stats; return this }
+
+        TransformerContext build() {
+            return new TransformerContext(path, is, relocators, stats)
+        }
+    }
+
+    /**
+     * @deprecated Use TransformerContext constructor instead.
+     */
+    @Deprecated
+    static Builder builder() {
+        return new Builder()
+    }
 
     static long getEntryTimestamp(boolean preserveFileTimestamps, long entryTime) {
         preserveFileTimestamps ? entryTime : ShadowCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES


### PR DESCRIPTION
Port deprecation annotations for legacy APIs from `main` to `8.x`.

### Deprecations
- #1722 - Deprecate `InheritManifest`
- #2124 - Deprecate `minimizeJar` property
- #2184 - Deprecate `TransformerContext.Builder`