### PR TITLE
Normalize line separators to LF in resource transformers for reproducible builds

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -15,6 +15,12 @@
 - **POTENTIALLY BREAKING:** Remove `Serializable` from `DependencyFilter`. ([#2144](https://github.com/GradleUp/shadow/pull/2144))
 - Bump default R8 from `9.1.31` to `9.4.14`. ([#2193](https://github.com/GradleUp/shadow/pull/2193))
 - Allow repackaging Service file classes with R8. ([#2174](https://github.com/GradleUp/shadow/pull/2174))
+- Normalize line separators to LF (`\n`) in `ResourceTransformer`s for reproducible builds. ([#2197](https://github.com/GradleUp/shadow/pull/2197))
+  - `ApacheNoticeResourceTransformer`
+  - `ComponentsXmlResourceTransformer`
+  - `GroovyExtensionModuleTransformer`
+  - `PropertiesFileTransformer`
+  - `XmlAppendingTransformer`
 
 ### Deprecated
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/ReproducibleProperties.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/ReproducibleProperties.kt
@@ -27,7 +27,7 @@ internal class ReproducibleProperties : Properties() {
         while (bufferedReader.readLine().also { line = it } != null && line != null) {
           if (!line.startsWith("#")) {
             write(line)
-            newLine()
+            write("\n")
           }
         }
       }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/Utils.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/Utils.kt
@@ -33,3 +33,9 @@ internal fun Properties.inputStream(
   os.writer(charset).use { writer -> store(writer, comments) }
   return os.toByteArray().inputStream()
 }
+
+@Suppress("NOTHING_TO_INLINE") // Syncs with `appendLine`.
+internal inline fun StringBuilder.appendLfLine(value: CharSequence? = null): StringBuilder = apply {
+  if (value != null) append(value)
+  append('\n')
+}

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -1,5 +1,6 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
+import com.github.jengelman.gradle.plugins.shadow.internal.appendLfLine
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
 import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.writeEntry
@@ -148,7 +149,7 @@ public open class ApacheNoticeResourceTransformer(
               sb.setLength(0)
             }
           }
-          sb.appendLine(line)
+          sb.appendLfLine(line)
           lineCount++
         } else {
           val entry = sb.toString()
@@ -187,18 +188,18 @@ public open class ApacheNoticeResourceTransformer(
       count++
       if (line == copyright && count != 2) continue
       if (count == 2 && copyright != null) {
-        sb.appendLine(copyright)
+        sb.appendLfLine(copyright)
       } else {
-        sb.appendLine(line)
+        sb.appendLfLine(line)
       }
       if (count == 3) {
         // Do org stuff.
         for ((key, value) in organizationEntries) {
-          sb.appendLine(key)
+          sb.appendLfLine(key)
           for (l in value) {
             sb.append(l)
           }
-          sb.appendLine()
+          sb.appendLfLine()
         }
       }
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer.kt
@@ -6,7 +6,9 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.relocateClass
 import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.PrintWriter
 import org.apache.tools.zip.ZipOutputStream
+import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter
 import org.codehaus.plexus.util.xml.XmlStreamReader
 import org.codehaus.plexus.util.xml.XmlStreamWriter
 import org.codehaus.plexus.util.xml.Xpp3Dom
@@ -38,7 +40,8 @@ public open class ComponentsXmlResourceTransformer : ResourceTransformer {
         for (component in components.values) {
           componentDom.addChild(component)
         }
-        Xpp3DomWriter.write(writer, dom)
+        val xmlWriter = PrettyPrintXMLWriter(PrintWriter(writer), "  ", "\n", null, null)
+        Xpp3DomWriter.write(xmlWriter, dom)
       }
       return os.toByteArray()
     }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer.kt
@@ -1,7 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
+import com.github.jengelman.gradle.plugins.shadow.internal.ReproducibleProperties
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
-import com.github.jengelman.gradle.plugins.shadow.internal.inputStream
 import com.github.jengelman.gradle.plugins.shadow.internal.writeEntry
 import com.github.jengelman.gradle.plugins.shadow.relocation.relocateClass
 import java.util.Properties
@@ -67,7 +67,9 @@ public open class GroovyExtensionModuleTransformer : ResourceTransformer {
 
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     os.writeEntry(PATH_GROOVY_EXTENSION_MODULE_DESCRIPTOR, preserveFileTimestamps) {
-      module.inputStream().use { it.copyTo(this) }
+      ReproducibleProperties()
+        .apply { putAll(module) }
+        .writeWithoutComments(Charsets.ISO_8859_1, this)
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
@@ -78,7 +78,7 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
 
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     os.writeEntry(resource.get(), preserveFileTimestamps) {
-      XMLOutputter(Format.getPrettyFormat()).output(doc, this)
+      XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n")).output(doc, this)
     }
     doc = null
   }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/ReproduciblePropertiesTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/ReproduciblePropertiesTest.kt
@@ -2,7 +2,6 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.github.jengelman.gradle.plugins.shadow.testkit.invariantEolString
 import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
 import org.junit.jupiter.params.ParameterizedTest
@@ -105,7 +104,6 @@ class ReproduciblePropertiesTest {
       return ByteArrayOutputStream()
         .also { writeWithoutComments(charset, it) }
         .toString(charset.name())
-        .invariantEolString
     }
   }
 }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
-import com.github.jengelman.gradle.plugins.shadow.testkit.invariantEolString
 import com.github.jengelman.gradle.plugins.shadow.util.zipOutputStream
 import org.junit.jupiter.api.Test
 
@@ -40,7 +39,7 @@ class AppendingTransformerTest : BaseTransformerTest<AppendingTransformer>() {
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent("test.properties") }.invariantEolString
+      val content = JarPath(tempJar).use { it.getContent("test.properties") }
       assertThat(content).isEqualTo("foo=bar\nbaz=qux")
     }
 
@@ -55,7 +54,7 @@ class AppendingTransformerTest : BaseTransformerTest<AppendingTransformer>() {
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent("application.yml") }.invariantEolString
+      val content = JarPath(tempJar).use { it.getContent("application.yml") }
       assertThat(content).isEqualTo("key1: val1\n---\nkey2: val2")
     }
 }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformerTest.kt
@@ -1,6 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
 import com.github.jengelman.gradle.plugins.shadow.testkit.requireResourceAsPath
 import kotlin.io.path.readText
@@ -20,11 +21,54 @@ class ComponentsXmlResourceTransformerTest :
       transform(resourceContext("components-1.xml"))
       transform(resourceContext("components-2.xml"))
 
+      val actualXml = transformedResource.decodeToString()
       val diff =
         XMLUnit.compareXML(
           requireResourceAsPath("components-expected.xml").readText(),
-          transformedResource.decodeToString(),
+          actualXml,
         )
       assertThat(diff.identical()).isTrue()
+      assertThat(actualXml)
+        .isEqualTo(
+          $$"""
+          |<component-set>
+          |  <components>
+          |    <component>
+          |      <role>org.apache.maven.wagon.Wagon</role>
+          |      <role-hint>http</role-hint>
+          |      <implementation>org.apache.maven.wagon.providers.http.LightweightHttpWagon</implementation>
+          |      <instantiation-strategy>per-lookup</instantiation-strategy>
+          |      <description>LightweightHttpWagon</description>
+          |      <isolated-realm>false</isolated-realm>
+          |      <configuration>
+          |        <httpHeaders>
+          |          <property>
+          |            <name>User-Agent</name>
+          |            <value>Apache Maven/${project.version}</value>
+          |          </property>
+          |        </httpHeaders>
+          |      </configuration>
+          |    </component>
+          |    <component>
+          |      <role>org.apache.maven.wagon.Wagon</role>
+          |      <role-hint>https</role-hint>
+          |      <implementation>org.apache.maven.wagon.providers.http.LightweightHttpsWagon</implementation>
+          |      <instantiation-strategy>per-lookup</instantiation-strategy>
+          |      <description>LIghtweightHttpsWagon</description>
+          |      <isolated-realm>false</isolated-realm>
+          |      <configuration>
+          |        <httpHeaders>
+          |          <property>
+          |            <name>User-Agent</name>
+          |            <value>Apache Maven/${project.version}</value>
+          |          </property>
+          |        </httpHeaders>
+          |      </configuration>
+          |    </component>
+          |  </components>
+          |</component-set>
+          """
+            .trimMargin()
+        )
     }
 }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
@@ -12,7 +12,6 @@ import com.github.jengelman.gradle.plugins.shadow.internal.inputStream
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
 import com.github.jengelman.gradle.plugins.shadow.testkit.getBytes
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
-import com.github.jengelman.gradle.plugins.shadow.testkit.invariantEolString
 import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer.MergeStrategy
 import com.github.jengelman.gradle.plugins.shadow.util.zipOutputStream
 import java.nio.charset.Charset
@@ -185,7 +184,7 @@ class PropertiesFileTransformerTest : BaseTransformerTest<PropertiesFileTransfor
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent(path) }.invariantEolString
+      val content = JarPath(tempJar).use { it.getContent(path) }
       assertThat(content).isEqualTo("foo=one,two\n")
     }
 

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformerTest.kt
@@ -46,7 +46,7 @@ class XmlAppendingTransformerTest : BaseTransformerTest<XmlAppendingTransformer>
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }.normalizeXmlEol()
+      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }
       assertThat(content)
         .isEqualTo(
           """
@@ -82,7 +82,7 @@ class XmlAppendingTransformerTest : BaseTransformerTest<XmlAppendingTransformer>
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }.normalizeXmlEol()
+      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }
       assertThat(content)
         .isEqualTo(
           """
@@ -115,7 +115,7 @@ class XmlAppendingTransformerTest : BaseTransformerTest<XmlAppendingTransformer>
       tempJar.zipOutputStream().use { zos ->
         modifyOutputStream(zos, false)
       }
-      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }.normalizeXmlEol()
+      val content = JarPath(tempJar).use { it.getContent(xmlEntry) }
       assertThat(content)
         .isEqualTo(
           """
@@ -128,15 +128,4 @@ class XmlAppendingTransformerTest : BaseTransformerTest<XmlAppendingTransformer>
             .trimMargin()
         )
     }
-
-  private companion object {
-    /**
-     * Normalizes line breaks in XML content produced by [XmlAppendingTransformer].
-     *
-     * JDOM2's [org.jdom2.output.Format.getPrettyFormat] defaults its line separator to `\r\n`
-     * (CRLF) across all platforms. Replacing `\r\n` with `\n` aligns the output with Kotlin's raw
-     * string literals (`"""|...""".trimMargin()`) for cross-platform assertions.
-     */
-    fun String.normalizeXmlEol(): String = replace("\r\n", "\n")
-  }
 }


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
