### PR TITLE
Fix `ManifestResourceTransformer.manifestEntries` value type to `Any` and support CC

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -22,6 +22,10 @@
   - `PropertiesFileTransformer`
   - `XmlAppendingTransformer`
 
+### Fixed
+
+- Fix `ManifestResourceTransformer.manifestEntries` value type to `Any` and support CC. ([#2198](https://github.com/GradleUp/shadow/pull/2198))
+
 ### Deprecated
 
 - Deprecate `keepRules` and `keepRuleFiles` in `R8Spec`. ([#2120](https://github.com/GradleUp/shadow/pull/2120))  

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -54,6 +54,31 @@ class TransformersTest : BaseTransformerTest() {
     commonAssertions()
   }
 
+  @Test
+  fun manifestResourceTransformer() {
+    writeClass()
+    projectScript.appendText(
+      transform<ManifestResourceTransformer>(
+        transformerBlock =
+          """
+          mainClass = 'my.Main'
+          manifestEntries = ['$TEST_ENTRY_ATTR_KEY': 'PASSED', 'Number-Entry': 123]
+          attributes '$NEW_ENTRY_ATTR_KEY': 'NEW'
+          """
+            .trimIndent()
+      )
+    )
+
+    runWithSuccess(shadowJarPath)
+
+    commonAssertions {
+      assertThat(getValue(TEST_ENTRY_ATTR_KEY)).isEqualTo("PASSED")
+      assertThat(getValue(mainClassAttributeKey)).isEqualTo("my.Main")
+      assertThat(getValue(NEW_ENTRY_ATTR_KEY)).isEqualTo("NEW")
+      assertThat(getValue("Number-Entry")).isEqualTo("123")
+    }
+  }
+
   @Test // #427
   fun mergeLog4j2PluginCacheFiles() {
     val content = requireResourceAsPath(PLUGIN_CACHE_FILE).readText()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -1,12 +1,11 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
-import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.internal.mapProperty
 import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.writeEntry
 import java.io.IOException
-import java.util.jar.Attributes as JarAttribute
+import java.util.jar.Attributes.Name as JarAttributeName
 import java.util.jar.JarFile.MANIFEST_NAME
 import java.util.jar.Manifest
 import javax.inject.Inject
@@ -38,8 +37,7 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
 
   @get:Input public open val mainClass: Property<String> = objectFactory.property("")
 
-  @get:Input
-  public open val manifestEntries: MapProperty<String, JarAttribute> = objectFactory.mapProperty()
+  @get:Input public open val manifestEntries: MapProperty<String, Any> = objectFactory.mapProperty()
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
     return MANIFEST_NAME.equals(element.path, ignoreCase = true).also { flag ->
@@ -72,16 +70,22 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
     }
 
     val attributes = manifest!!.mainAttributes
-    mainClass.get().takeIf(CharSequence::isNotEmpty)?.let { attributes[mainClassAttributeKey] = it }
-    manifestEntries.get().forEach { (key, value) -> attributes[JarAttribute.Name(key)] = value }
+    mainClass.get().takeIf(CharSequence::isNotEmpty)?.let {
+      attributes[JarAttributeName.MAIN_CLASS] = it
+    }
+    manifestEntries.get().forEach { (key, value) -> attributes.putValue(key, value.toString()) }
 
     os.writeEntry(MANIFEST_NAME, preserveFileTimestamps) {
       manifest!!.write(this)
     }
   }
 
-  public open fun attributes(attributes: Map<String, JarAttribute>) {
-    manifestEntries.putAll(attributes)
+  public open fun attributes(attributes: Map<String, *>) {
+    attributes.forEach { (key, value) ->
+      if (value != null) {
+        manifestEntries.put(key, value)
+      }
+    }
   }
 
   private companion object {


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
