### PR TITLE
Improve service file relocation and append terminating newline in `ServiceFileTransformer`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -120,6 +120,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/relocation/Relocat
 }
 
 public final class com/github/jengelman/gradle/plugins/shadow/relocation/RelocationContextKt {
+	public static final fun applyToSourceContent (Ljava/lang/Iterable;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun relocateClass (Lcom/github/jengelman/gradle/plugins/shadow/relocation/Relocator;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun relocateClass (Ljava/lang/Iterable;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun relocatePath (Lcom/github/jengelman/gradle/plugins/shadow/relocation/Relocator;Ljava/lang/String;)Ljava/lang/String;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -7,6 +7,7 @@
 
 - Allow configuring the final R8 configuration file with `R8Spec.configurationFile`. ([#2133](https://github.com/GradleUp/shadow/pull/2133))
 - Add `ProGuardFilesResourceTransformer` to merge R8/ProGuard rule files. ([#2196](https://github.com/GradleUp/shadow/pull/2196))
+- Add `Iterable<Relocator>.applyToSourceContent` extension function. ([#2201](https://github.com/GradleUp/shadow/pull/2201))
 
 ### Changed
 
@@ -25,6 +26,8 @@
 ### Fixed
 
 - Fix `ManifestResourceTransformer.manifestEntries` value type to `Any` and support CC. ([#2198](https://github.com/GradleUp/shadow/pull/2198))
+- Fix `ServiceFileTransformer` to properly relocate content with comments or whitespace and append a terminating newline. ([#2201](https://github.com/GradleUp/shadow/pull/2201))
+- Fix `SimpleRelocator.shadeSourceWithExcludes` when the source content starts with the pattern to relocate. ([#2201](https://github.com/GradleUp/shadow/pull/2201))
 
 ### Deprecated
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -39,7 +39,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     val content = outputShadowedJar.use { it.getContent(ENTRY_FOO_SHADE) }
-    assertThat(content).isEqualTo(CONTENT_ONE_TWO)
+    assertThat(content).isEqualTo("$CONTENT_ONE_TWO\n")
   }
 
   @Test
@@ -96,7 +96,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
           """
           |relocated.foo.FooDriver
           |relocated.bar.BarDriver
-          """
+          |"""
             .trimMargin()
         )
     }
@@ -188,7 +188,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     val content = outputShadowedJar.use { it.getContent(servicesBarEntry) }
-    assertThat(content).isEqualTo("$CONTENT_THREE\n$CONTENT_ONE_TWO")
+    assertThat(content).isEqualTo("$CONTENT_THREE\n$CONTENT_ONE_TWO\n")
   }
 
   @ParameterizedTest
@@ -221,8 +221,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     }
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(firstValue)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo(secondValue)
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$firstValue\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("$secondValue\n")
     }
   }
 
@@ -243,8 +243,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 
@@ -265,8 +265,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 
@@ -294,8 +294,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocationContext.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/RelocationContext.kt
@@ -29,3 +29,13 @@ public fun Iterable<Relocator>.relocatePath(path: String): String {
   }
   return path
 }
+
+public fun Iterable<Relocator>.applyToSourceContent(sourceContent: String): String {
+  var result = sourceContent
+  for (relocator in this) {
+    if (relocator.canRelocateClass(result)) {
+      result = relocator.applyToSourceContent(result)
+    }
+  }
+  return result
+}

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt
@@ -255,9 +255,7 @@ constructor(
       // Make sure that search pattern starts at word boundary and that we look for literal ".", not
       // regex jokers.
       val snippets =
-        sourceContent
-          .split(("\\b" + patternFrom.replace(".", "[.]") + "\\b").toRegex())
-          .filter(CharSequence::isNotEmpty)
+        sourceContent.split(("\\b" + patternFrom.replace(".", "[.]") + "\\b").toRegex())
       snippets.forEachIndexed { i, snippet ->
         val isFirstSnippet = i == 0
         val previousSnippet = if (isFirstSnippet) "" else snippets[i - 1]

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
@@ -2,6 +2,7 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
 import com.github.jengelman.gradle.plugins.shadow.internal.writeEntry
+import com.github.jengelman.gradle.plugins.shadow.relocation.applyToSourceContent
 import com.github.jengelman.gradle.plugins.shadow.relocation.relocateClass
 import com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer.Companion.PATH_LEGACY_GROOVY_EXTENSION_MODULE_DESCRIPTOR
 import org.apache.tools.zip.ZipOutputStream
@@ -52,7 +53,7 @@ constructor(
     context.inputStream
       .bufferedReader()
       .use { it.readLines() }
-      .forEach { line -> out.add(context.relocators.relocateClass(line)) }
+      .forEach { line -> out.add(context.relocators.applyToSourceContent(line)) }
   }
 
   override fun hasTransformedResource(): Boolean = serviceEntries.isNotEmpty()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
@@ -61,7 +61,7 @@ constructor(
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     serviceEntries.forEach { (path, data) ->
       os.writeEntry(path, preserveFileTimestamps) {
-        write(data.joinToString("\n").toByteArray())
+        write(data.joinToString(separator = "\n", postfix = "\n").toByteArray())
       }
     }
   }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -131,6 +131,23 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.blah.Service")
     }
 
+  @Test
+  fun serviceFileWithComments() =
+    with(ServiceFileTransformer()) {
+      val relocator = SimpleRelocator("org.foo", "borg.foo")
+      val content = "# Service provider config\norg.foo.Service # default\n"
+      val contentResource = "META-INF/services/org.something.another"
+      transform(textContext(contentResource, content, relocator))
+
+      tempJar.zipOutputStream().use { zos ->
+        modifyOutputStream(zos, false)
+      }
+
+      val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
+      assertThat(transformedContent)
+        .isEqualTo("# Service provider config\nborg.foo.Service # default")
+    }
+
   private companion object {
     @JvmStatic
     fun resourceProvider() =

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -71,7 +71,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResourceShaded) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService\n")
     }
 
   @Test
@@ -90,7 +90,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResourceShaded) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService\n")
     }
 
   @Test
@@ -107,7 +107,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
-      assertThat(transformedContent).isEqualTo("org.eclipse1234.osgi.launch.EquinoxFactory")
+      assertThat(transformedContent).isEqualTo("org.eclipse1234.osgi.launch.EquinoxFactory\n")
     }
 
   @Test
@@ -128,7 +128,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.blah.Service")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.blah.Service\n")
     }
 
   @Test
@@ -145,7 +145,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
       assertThat(transformedContent)
-        .isEqualTo("# Service provider config\nborg.foo.Service # default")
+        .isEqualTo("# Service provider config\nborg.foo.Service # default\n")
     }
 
   private companion object {


### PR DESCRIPTION
- Relocate service file content using `applyToSourceContent` in `ServiceFileTransformer` (modified from https://github.com/apache/maven-shade-plugin/commit/b75bc04014983775a11c7f4d0fecc32ebcd875cb).
- Fix `SimpleRelocator.shadeSourceWithExcludes` split behavior.
- Add `Iterable<Relocator>.applyToSourceContent` extension function in `RelocationContext.kt`.
- Append terminating newline when writing service files in `ServiceFileTransformer` (modified from https://github.com/apache/maven-shade-plugin/commit/c18d3d3e36f4d37aba98a18983bd4e56eba79327).

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.