### PR TITLE
Append terminating newline in `ServiceFileTransformer`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -21,6 +21,7 @@
   - `GroovyExtensionModuleTransformer`
   - `PropertiesFileTransformer`
   - `XmlAppendingTransformer`
+- Append terminating newline in `ServiceFileTransformer`. ([#2202](https://github.com/GradleUp/shadow/pull/2202))
 
 ### Fixed
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -39,7 +39,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     val content = outputShadowedJar.use { it.getContent(ENTRY_FOO_SHADE) }
-    assertThat(content).isEqualTo(CONTENT_ONE_TWO)
+    assertThat(content).isEqualTo("$CONTENT_ONE_TWO\n")
   }
 
   @Test
@@ -96,7 +96,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
           """
           |relocated.foo.FooDriver
           |relocated.bar.BarDriver
-          """
+          |"""
             .trimMargin()
         )
     }
@@ -188,7 +188,7 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     val content = outputShadowedJar.use { it.getContent(servicesBarEntry) }
-    assertThat(content).isEqualTo("$CONTENT_THREE\n$CONTENT_ONE_TWO")
+    assertThat(content).isEqualTo("$CONTENT_THREE\n$CONTENT_ONE_TWO\n")
   }
 
   @ParameterizedTest
@@ -221,8 +221,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     }
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(firstValue)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo(secondValue)
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$firstValue\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("$secondValue\n")
     }
   }
 
@@ -243,8 +243,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 
@@ -265,8 +265,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 
@@ -294,8 +294,8 @@ class ServiceFileTransformerTest : BaseTransformerTest() {
     runWithSuccess(shadowJarPath)
 
     assertThat(outputShadowedJar).useAll {
-      getContent(ENTRY_SERVICES_SHADE).isEqualTo(CONTENT_ONE_TWO)
-      getContent(ENTRY_SERVICES_FOO).isEqualTo("one")
+      getContent(ENTRY_SERVICES_SHADE).isEqualTo("$CONTENT_ONE_TWO\n")
+      getContent(ENTRY_SERVICES_FOO).isEqualTo("one\n")
     }
   }
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformer.kt
@@ -60,7 +60,7 @@ constructor(
   override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
     serviceEntries.forEach { (path, data) ->
       os.writeEntry(path, preserveFileTimestamps) {
-        write(data.joinToString("\n").toByteArray())
+        write(data.joinToString(separator = "\n", postfix = "\n").toByteArray())
       }
     }
   }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ServiceFileTransformerTest.kt
@@ -71,7 +71,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResourceShaded) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService\n")
     }
 
   @Test
@@ -90,7 +90,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResourceShaded) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.foo.exclude.OtherService\n")
     }
 
   @Test
@@ -107,7 +107,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
-      assertThat(transformedContent).isEqualTo("org.eclipse1234.osgi.launch.EquinoxFactory")
+      assertThat(transformedContent).isEqualTo("org.eclipse1234.osgi.launch.EquinoxFactory\n")
     }
 
   @Test
@@ -128,7 +128,7 @@ class ServiceFileTransformerTest : BaseTransformerTest<ServiceFileTransformer>()
       }
 
       val transformedContent = JarPath(tempJar).use { it.getContent(contentResource) }
-      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.blah.Service")
+      assertThat(transformedContent).isEqualTo("borg.foo.Service\norg.blah.Service\n")
     }
 
   private companion object {


### PR DESCRIPTION
Modified from 

- https://github.com/apache/maven-shade-plugin/commit/c18d3d3e36f4d37aba98a18983bd4e56eba79327
- https://issues.apache.org/jira/browse/MSHADE-401
- https://github.com/apache/maven-shade-plugin/issues/648

Closes #2201.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.