### PR TITLE
Mark `ObjectFactory`-injected `ResourceTransformer`s as `abstract`

### DIFF
--- a/api/shadow.api
+++ b/api/shadow.api
@@ -315,7 +315,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicen
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -336,7 +336,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNotic
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public static final field Companion Lcom/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer$Companion;
 	public static final field DEFAULT_SEPARATOR Ljava/lang/String;
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
@@ -368,7 +368,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsX
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/ComponentsXmlResourceTransformer$Companion {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -377,7 +377,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/Deduplicati
 	public fun modifyOutputStream (Lorg/apache/tools/zip/ZipOutputStream;Z)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getName ()Ljava/lang/String;
@@ -408,7 +408,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExten
 public final class com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformer$Companion {
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getFile ()Lorg/gradle/api/file/RegularFileProperty;
@@ -420,7 +420,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/IncludeReso
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/KotlinModuleMetadataTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/KotlinModuleMetadataTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -438,7 +438,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/Log4j2Plugi
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun append (Ljava/lang/String;Ljava/lang/Comparable;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -449,7 +449,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestApp
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun attributes (Ljava/util/Map;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -461,7 +461,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ManifestRes
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/MergeLicenseResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/MergeLicenseResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -500,7 +500,7 @@ public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/Pa
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
@@ -519,7 +519,7 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ProGuardFil
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getCharsetName ()Lorg/gradle/api/provider/Property;
@@ -613,7 +613,7 @@ public final class com/github/jengelman/gradle/plugins/shadow/transformers/Trans
 	public final fun builder ()Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext$Builder;
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public abstract class com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getIgnoreDtd ()Lorg/gradle/api/provider/Property;

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -22,7 +22,7 @@
   - `PropertiesFileTransformer`
   - `XmlAppendingTransformer`
 - Append terminating newline in `ServiceFileTransformer`. ([#2202](https://github.com/GradleUp/shadow/pull/2202))
-- **POTENTIALLY BREAKING:** Mark `abstract` for `ObjectFactory`-injected `ResourceTransformer`s. ([#2205](https://github.com/GradleUp/shadow/pull/2205))
+- **POTENTIALLY BREAKING:** Mark `ObjectFactory`-injected `ResourceTransformer`s as `abstract`. ([#2205](https://github.com/GradleUp/shadow/pull/2205))
   - `ApacheNoticeResourceTransformer`
   - `AppendingTransformer`
   - `DeduplicatingResourceTransformer`

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -22,6 +22,19 @@
   - `PropertiesFileTransformer`
   - `XmlAppendingTransformer`
 - Append terminating newline in `ServiceFileTransformer`. ([#2202](https://github.com/GradleUp/shadow/pull/2202))
+- **POTENTIALLY BREAKING:** Mark `abstract` for `ObjectFactory`-injected `ResourceTransformer`s. ([#2205](https://github.com/GradleUp/shadow/pull/2205))
+  - `ApacheNoticeResourceTransformer`
+  - `AppendingTransformer`
+  - `DeduplicatingResourceTransformer`
+  - `DontIncludeResourceTransformer`
+  - `IncludeResourceTransformer`
+  - `KotlinModuleMetadataTransformer`
+  - `ManifestAppenderTransformer`
+  - `ManifestResourceTransformer`
+  - `MergeLicenseResourceTransformer`
+  - `PreserveFirstFoundResourceTransformer`
+  - `PropertiesFileTransformer`
+  - `XmlAppendingTransformer`
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheNoticeResourceTransformer.kt
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.util.PatternSet
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ApacheNoticeResourceTransformer(
+public abstract class ApacheNoticeResourceTransformer(
   final override val objectFactory: ObjectFactory,
   patternSet: PatternSet,
 ) : PatternFilterableResourceTransformer(patternSet) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformer.kt
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.Input
  * @author John Engelman
  */
 @CacheableTransformer
-public open class AppendingTransformer
+public abstract class AppendingTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var _data: ByteArrayOutputStream? =

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
@@ -56,7 +56,7 @@ import org.gradle.api.tasks.util.PatternSet
  * behavior.
  */
 @CacheableTransformer
-public open class DeduplicatingResourceTransformer(
+public abstract class DeduplicatingResourceTransformer(
   final override val objectFactory: ObjectFactory,
   patternSet: PatternSet,
 ) : PatternFilterableResourceTransformer(patternSet) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DontIncludeResourceTransformer.kt
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.Input
   replaceWith = ReplaceWith("exclude"),
 )
 @CacheableTransformer
-public open class DontIncludeResourceTransformer
+public abstract class DontIncludeResourceTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) :
   ResourceTransformer by ResourceTransformer.Companion {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/IncludeResourceTransformer.kt
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.PathSensitivity
   replaceWith = ReplaceWith("from"),
 )
 @CacheableTransformer
-public open class IncludeResourceTransformer
+public abstract class IncludeResourceTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) :
   ResourceTransformer by ResourceTransformer.Companion {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/KotlinModuleMetadataTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/KotlinModuleMetadataTransformer.kt
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.util.PatternSet
  * (`.kotlin_module`).
  */
 @CacheableTransformer
-public open class KotlinModuleMetadataTransformer(
+public abstract class KotlinModuleMetadataTransformer(
   final override val objectFactory: ObjectFactory,
   patternSet: PatternSet,
 ) : PatternFilterableResourceTransformer(patternSet) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.Input
  * @author Chris Rankin
  */
 @CacheableTransformer
-public open class ManifestAppenderTransformer
+public abstract class ManifestAppenderTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var manifestContents = ByteArray(0)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestResourceTransformer.kt
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.Input
  * @author John Engelman
  */
 @CacheableTransformer
-public open class ManifestResourceTransformer
+public abstract class ManifestResourceTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var manifestDiscovered = false

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/MergeLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/MergeLicenseResourceTransformer.kt
@@ -39,7 +39,7 @@ import org.gradle.api.tasks.util.PatternSet
  * files to include, the paths mentioned above are then not considered unless explicitly included.
  */
 @CacheableTransformer
-public open class MergeLicenseResourceTransformer(
+public abstract class MergeLicenseResourceTransformer(
   final override val objectFactory: ObjectFactory,
   patternSet: PatternSet,
 ) : PatternFilterableResourceTransformer(patternSet) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PreserveFirstFoundResourceTransformer.kt
@@ -32,7 +32,7 @@ import org.gradle.api.tasks.util.PatternSet
  * @see [ShadowJar.getDuplicatesStrategy]
  */
 @CacheableTransformer
-public open class PreserveFirstFoundResourceTransformer(
+public abstract class PreserveFirstFoundResourceTransformer(
   final override val objectFactory: ObjectFactory,
   patternSet: PatternSet,
 ) : PatternFilterableResourceTransformer(patternSet) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
@@ -99,7 +99,7 @@ import org.gradle.api.tasks.Internal
  * @author Marc Philipp
  */
 @CacheableTransformer
-public open class PropertiesFileTransformer
+public abstract class PropertiesFileTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private inline val charset

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer.kt
@@ -51,7 +51,7 @@ public interface ResourceTransformer : Named {
     @JvmStatic
     public fun <T : ResourceTransformer> Class<T>.create(objectFactory: ObjectFactory): T {
       // If the constructor takes a single ObjectFactory, inject it in.
-      val constructor = constructors.find {
+      val constructor = declaredConstructors.find {
         it.parameterTypes.singleOrNull() == ObjectFactory::class.java
       }
       return if (constructor != null) {

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/XmlAppendingTransformer.kt
@@ -29,7 +29,7 @@ import org.xml.sax.InputSource
  * @author John Engelman
  */
 @CacheableTransformer
-public open class XmlAppendingTransformer
+public abstract class XmlAppendingTransformer
 @Inject
 constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
   private var doc: Document? = null

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DuplicatesStrategyCheckerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DuplicatesStrategyCheckerTest.kt
@@ -3,6 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.github.jengelman.gradle.plugins.shadow.transformers.BaseTransformerTest.Companion.canTransformResource
+import com.github.jengelman.gradle.plugins.shadow.transformers.PatternFilterableResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer.Companion.create
 import com.github.jengelman.gradle.plugins.shadow.util.testObjectFactory
@@ -56,7 +57,11 @@ private fun getTransformerClasses(): List<Class<out ResourceTransformer>> {
     runCatching {
       val clazz = Class.forName(className)
       with(clazz.kotlin) {
-        if (isSubclassOf(parentClass) && !isAbstract) {
+        if (
+          !java.isInterface &&
+            isSubclassOf(parentClass) &&
+            clazz != PatternFilterableResourceTransformer::class.java
+        ) {
           @Suppress("UNCHECKED_CAST") classes.add(clazz as Class<out ResourceTransformer>)
         }
       }


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
