### PR TITLE
Avoid overwriting entries that differ only by case on case-insensitive filesystems

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -37,6 +37,7 @@
 ### Fixed
 
 - Fix `ManifestResourceTransformer.manifestEntries` value type to `Any` and support CC. ([#2198](https://github.com/GradleUp/shadow/pull/2198))
+- Avoid overwriting entries that differ only by case on case-insensitive OS. ([#2213](https://github.com/GradleUp/shadow/pull/2213))
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -37,7 +37,7 @@
 ### Fixed
 
 - Fix `ManifestResourceTransformer.manifestEntries` value type to `Any` and support CC. ([#2198](https://github.com/GradleUp/shadow/pull/2198))
-- Avoid overwriting entries that differ only by case on case-insensitive OS. ([#2213](https://github.com/GradleUp/shadow/pull/2213))
+- Avoid overwriting entries that differ only by case on case-insensitive filesystems. ([#2213](https://github.com/GradleUp/shadow/pull/2213))
 
 ## [9.6.1](https://github.com/GradleUp/shadow/releases/tag/9.6.1) - 2026-07-22
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/RelocationTest.kt
@@ -678,6 +678,47 @@ class RelocationTest : BasePluginTest() {
     }
   }
 
+  @Test
+  fun relocateCaseSensitiveAndInsensitiveClassesInJar() {
+    val fooJar =
+      buildJar("foo.jar") {
+        insert("foo/Bar.class", createEmptyClassBytes("foo/Bar"))
+        insert("foo/bar.class", createEmptyClassBytes("foo/bar"))
+      }
+    projectScript.appendText(
+      """
+      |dependencies {
+      |  ${implementationFiles(fooJar)}
+      |}
+      |$shadowJarTask {
+      |  relocate 'foo', 'shadow.foo'
+      |}
+      """
+        .trimMargin()
+    )
+
+    runWithSuccess(shadowJarPath)
+
+    assertThat(outputShadowedJar).useAll {
+      containsOnly(
+        "shadow/",
+        "shadow/foo/",
+        "shadow/foo/Bar.class",
+        "shadow/foo/bar.class",
+        *manifestEntries,
+      )
+
+      val upperBytes = getBytes("shadow/foo/Bar.class")
+      val lowerBytes = getBytes("shadow/foo/bar.class")
+      assertThat(upperBytes).isNotEqualTo(lowerBytes)
+
+      classLoader {
+        loadClass("shadow.foo.Bar")
+        loadClass("shadow.foo.bar")
+      }
+    }
+  }
+
   private fun writeClassWithStringRef() {
     writeClass {
       """

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -153,11 +153,10 @@ class TransformersTest : BaseTransformerTest() {
 
   @Test
   fun deduplicatingResourceTransformerWithCaseSensitiveEntries() {
-    val one =
-      buildJar("one.jar") {
-        insert("foo/Bar.txt", "Bar")
-        insert("foo/bar.txt", "bar")
-      }
+    val one = buildJarOne {
+      insert("foo/Bar.txt", "Bar")
+      insert("foo/bar.txt", "bar")
+    }
     projectScript.appendText(
       transform<DeduplicatingResourceTransformer>(dependenciesBlock = implementationFiles(one))
     )

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -151,6 +151,26 @@ class TransformersTest : BaseTransformerTest() {
     assertThat(outputShadowedJar).useAll { containsOnly(*entriesInAB, *manifestEntries) }
   }
 
+  @Test
+  fun deduplicatingResourceTransformerWithCaseSensitiveEntries() {
+    val one =
+      buildJar("one.jar") {
+        insert("foo/Bar.txt", "Bar")
+        insert("foo/bar.txt", "bar")
+      }
+    projectScript.appendText(
+      transform<DeduplicatingResourceTransformer>(dependenciesBlock = implementationFiles(one))
+    )
+
+    runWithSuccess(shadowJarPath)
+
+    assertThat(outputShadowedJar).useAll {
+      containsOnly("foo/", "foo/Bar.txt", "foo/bar.txt", *manifestEntries)
+      getContent("foo/Bar.txt").isEqualTo("Bar")
+      getContent("foo/bar.txt").isEqualTo("bar")
+    }
+  }
+
   private fun commonAssertions(
     mainAttributesBlock: JarAttribute.() -> Unit = {
       assertThat(getValue(TEST_ENTRY_ATTR_KEY)).isEqualTo("PASSED")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
@@ -21,15 +21,6 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.jvm.toolchain.JavaToolchainService
 
-internal inline val FileTreeElement.inputStream: InputStream
-  get() =
-    try {
-      // Open is more performant than getFile, it doesn't extract the zip files.
-      open()
-    } catch (_: UnsupportedOperationException) {
-      file.inputStream()
-    }
-
 /** Return `runtimeClasspath` or `runtime` configuration. */
 internal inline val Project.runtimeConfiguration: Configuration
   get() =
@@ -69,6 +60,14 @@ internal fun Project.addBuildScanCustomValues() {
     }
   }
 }
+
+internal fun FileTreeElement.inputStream(): InputStream =
+  try {
+    // Open is more performant than getFile, it doesn't extract the zip files.
+    open()
+  } catch (_: UnsupportedOperationException) {
+    file.inputStream()
+  }
 
 internal inline fun <reified V : Any> ObjectFactory.property(
   defaultValue: Any? = null

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
@@ -2,10 +2,12 @@ package com.github.jengelman.gradle.plugins.shadow.internal
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import java.io.InputStream
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileTreeElement
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.plugins.JavaApplication
@@ -18,6 +20,15 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.jvm.toolchain.JavaToolchainService
+
+internal inline val FileTreeElement.inputStream: InputStream
+  get() =
+    try {
+      // Open is more performant than getFile, it doesn't extract the zip files.
+      open()
+    } catch (_: UnsupportedOperationException) {
+      file.inputStream()
+    }
 
 /** Return `runtimeClasspath` or `runtime` configuration. */
 internal inline val Project.runtimeConfiguration: Configuration

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -13,34 +13,29 @@ import org.vafer.jdeb.shaded.objectweb.asm.commons.Remapper
  * Applies remapping to the given class file using the provided relocators and returns the
  * (possibly) remapped class bytes. If no remapping is required, the original bytes are returned.
  */
-internal fun FileCopyDetails.remapClass(relocators: Set<Relocator>): ByteArray {
-  val bytes =
-    try {
-      // Open is more performant than getFile, it doesn't extract the zip files.
-      open().use { it.readBytes() }
-    } catch (_: UnsupportedOperationException) {
-      file.readBytes()
+internal fun FileCopyDetails.remapClass(relocators: Set<Relocator>): ByteArray =
+  inputStream
+    .use { it.readBytes() }
+    .let { bytes ->
+      var modified = false
+      val remapper = RelocatorRemapper(relocators) { modified = true }
+
+      // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant
+      // pool. Copying the original constant pool should be avoided because it would keep references
+      // to the original class names. This is not a problem at runtime (because these entries in the
+      // constant pool are never used), but confuses some tools such as Felix's maven-bundle-plugin
+      // that use the constant pool to determine the dependencies of a class.
+      try {
+        val cw = ClassWriter(0)
+        val cr = ClassReader(bytes)
+        val cv = ClassRemapper(cw, remapper)
+        cr.accept(cv, ClassReader.EXPAND_FRAMES)
+        // If we didn't need to change anything, keep the original bytes as-is.
+        if (modified) cw.toByteArray() else bytes
+      } catch (t: Throwable) {
+        throw GradleException("Error in ASM processing class $path", t)
+      }
     }
-
-  var modified = false
-  val remapper = RelocatorRemapper(relocators) { modified = true }
-
-  // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
-  // Copying the original constant pool should be avoided because it would keep references to the
-  // original class names. This is not a problem at runtime (because these entries in the constant
-  // pool are never used), but confuses some tools such as Felix's maven-bundle-plugin that use
-  // the constant pool to determine the dependencies of a class.
-  return try {
-    val cw = ClassWriter(0)
-    val cr = ClassReader(bytes)
-    val cv = ClassRemapper(cw, remapper)
-    cr.accept(cv, ClassReader.EXPAND_FRAMES)
-    // If we didn't need to change anything, keep the original bytes as-is.
-    if (modified) cw.toByteArray() else bytes
-  } catch (t: Throwable) {
-    throw GradleException("Error in ASM processing class $path", t)
-  }
-}
 
 private class RelocatorRemapper(
   private val relocators: Set<Relocator>,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -13,27 +13,34 @@ import org.vafer.jdeb.shaded.objectweb.asm.commons.Remapper
  * Applies remapping to the given class file using the provided relocators and returns the
  * (possibly) remapped class bytes. If no remapping is required, the original bytes are returned.
  */
-internal fun FileCopyDetails.remapClass(relocators: Set<Relocator>): ByteArray =
-  file.readBytes().let { bytes ->
-    var modified = false
-    val remapper = RelocatorRemapper(relocators) { modified = true }
-
-    // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
-    // Copying the original constant pool should be avoided because it would keep references to the
-    // original class names. This is not a problem at runtime (because these entries in the constant
-    // pool are never used), but confuses some tools such as Felix's maven-bundle-plugin that use
-    // the constant pool to determine the dependencies of a class.
+internal fun FileCopyDetails.remapClass(relocators: Set<Relocator>): ByteArray {
+  val bytes =
     try {
-      val cw = ClassWriter(0)
-      val cr = ClassReader(bytes)
-      val cv = ClassRemapper(cw, remapper)
-      cr.accept(cv, ClassReader.EXPAND_FRAMES)
-      // If we didn't need to change anything, keep the original bytes as-is.
-      if (modified) cw.toByteArray() else bytes
-    } catch (t: Throwable) {
-      throw GradleException("Error in ASM processing class $path", t)
+      // Open is more performant than getFile, it doesn't extract the zip files.
+      open().use { it.readBytes() }
+    } catch (_: UnsupportedOperationException) {
+      file.readBytes()
     }
+
+  var modified = false
+  val remapper = RelocatorRemapper(relocators) { modified = true }
+
+  // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
+  // Copying the original constant pool should be avoided because it would keep references to the
+  // original class names. This is not a problem at runtime (because these entries in the constant
+  // pool are never used), but confuses some tools such as Felix's maven-bundle-plugin that use
+  // the constant pool to determine the dependencies of a class.
+  return try {
+    val cw = ClassWriter(0)
+    val cr = ClassReader(bytes)
+    val cv = ClassRemapper(cw, remapper)
+    cr.accept(cv, ClassReader.EXPAND_FRAMES)
+    // If we didn't need to change anything, keep the original bytes as-is.
+    if (modified) cw.toByteArray() else bytes
+  } catch (t: Throwable) {
+    throw GradleException("Error in ASM processing class $path", t)
   }
+}
 
 private class RelocatorRemapper(
   private val relocators: Set<Relocator>,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/RelocatorRemapper.kt
@@ -14,7 +14,7 @@ import org.vafer.jdeb.shaded.objectweb.asm.commons.Remapper
  * (possibly) remapped class bytes. If no remapping is required, the original bytes are returned.
  */
 internal fun FileCopyDetails.remapClass(relocators: Set<Relocator>): ByteArray =
-  inputStream
+  inputStream()
     .use { it.readBytes() }
     .let { bytes ->
       var modified = false

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -204,9 +204,16 @@ internal constructor(
 
     private fun transform(fileDetails: FileCopyDetails, path: String): Boolean {
       val transformer = transformers.find { it.canTransformResource(fileDetails) } ?: return false
-      fileDetails.file.inputStream().use { inputStream ->
+      val inputStream =
+        try {
+          // Open is more performant than getFile, it doesn't extract the zip files.
+          fileDetails.open()
+        } catch (_: UnsupportedOperationException) {
+          fileDetails.file.inputStream()
+        }
+      inputStream.use {
         transformer.transform(
-          TransformerContext(path = path, inputStream = inputStream, relocators = relocators)
+          TransformerContext(path = path, inputStream = it, relocators = relocators)
         )
       }
       return true

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -6,6 +6,7 @@ package com.github.jengelman.gradle.plugins.shadow.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.internal.UnixMode
 import com.github.jengelman.gradle.plugins.shadow.internal.cast
+import com.github.jengelman.gradle.plugins.shadow.internal.inputStream
 import com.github.jengelman.gradle.plugins.shadow.internal.parentDirectoryEntries
 import com.github.jengelman.gradle.plugins.shadow.internal.remapClass
 import com.github.jengelman.gradle.plugins.shadow.internal.writeEntry
@@ -204,14 +205,7 @@ internal constructor(
 
     private fun transform(fileDetails: FileCopyDetails, path: String): Boolean {
       val transformer = transformers.find { it.canTransformResource(fileDetails) } ?: return false
-      val inputStream =
-        try {
-          // Open is more performant than getFile, it doesn't extract the zip files.
-          fileDetails.open()
-        } catch (_: UnsupportedOperationException) {
-          fileDetails.file.inputStream()
-        }
-      inputStream.use {
+      fileDetails.inputStream.use {
         transformer.transform(
           TransformerContext(path = path, inputStream = it, relocators = relocators)
         )

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowCopyAction.kt
@@ -205,9 +205,9 @@ internal constructor(
 
     private fun transform(fileDetails: FileCopyDetails, path: String): Boolean {
       val transformer = transformers.find { it.canTransformResource(fileDetails) } ?: return false
-      fileDetails.inputStream.use {
+      fileDetails.inputStream().use { inputStream ->
         transformer.transform(
-          TransformerContext(path = path, inputStream = it, relocators = relocators)
+          TransformerContext(path = path, inputStream = inputStream, relocators = relocators)
         )
       }
       return true

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
@@ -92,7 +92,8 @@ public open class DeduplicatingResourceTransformer(
           append("  * $path\n")
           infos.elementsPerHash.forEach { (hash, elements) ->
             elements.forEach { element ->
-              val filePath = runCatching { element.file.path }.getOrElse { element.path }
+              // Formats as `file '<path>'` for local files or `zip entry '<jar>!<entry>'`.
+              val filePath = element.toString()
               append("    * $filePath (SHA256: $hash)\n")
             }
           }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
@@ -3,6 +3,7 @@ package com.github.jengelman.gradle.plugins.shadow.transformers
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
 import com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath
 import java.io.File
+import java.io.InputStream
 import java.security.MessageDigest
 import java.util.HexFormat
 import javax.inject.Inject
@@ -65,14 +66,13 @@ public open class DeduplicatingResourceTransformer(
   @Inject public constructor(objectFactory: ObjectFactory) : this(objectFactory, PatternSet())
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val file = element.file
-    val hash = file.sha256Hex()
+    val hash = element.sha256Hex()
 
     val flag = patternSpec.isSatisfiedBy(element)
     checkDupStrategy(flag, element)
 
     val pathInfos = sources.computeIfAbsent(element.path) { PathInfos(flag) }
-    val retainInOutput = pathInfos.addFile(hash, file)
+    val retainInOutput = pathInfos.addElement(hash, element)
 
     return !retainInOutput
   }
@@ -89,8 +89,16 @@ public open class DeduplicatingResourceTransformer(
         )
         duplicatePaths.forEach { (path, infos) ->
           append("  * $path\n")
-          infos.filesPerHash.forEach { (hash, files) ->
-            files.forEach { file -> append("    * ${file.path} (SHA256: $hash)\n") }
+          infos.elementsPerHash.forEach { (hash, elements) ->
+            elements.forEach { element ->
+              val filePath =
+                try {
+                  element.file.path
+                } catch (_: Exception) {
+                  element.path
+                }
+              append("    * $filePath (SHA256: $hash)\n")
+            }
           }
         }
       }
@@ -104,33 +112,44 @@ public open class DeduplicatingResourceTransformer(
     }
 
   internal data class PathInfos(val failOnDuplicateContent: Boolean) {
-    val filesPerHash: MutableMap<String, MutableList<File>> = mutableMapOf()
+    val elementsPerHash: MutableMap<String, MutableList<FileTreeElement>> = mutableMapOf()
 
-    fun uniqueContentCount() = filesPerHash.size
+    fun uniqueContentCount() = elementsPerHash.size
 
-    fun addFile(hash: String, file: File): Boolean {
-      val new = hash !in filesPerHash
-      filesPerHash.getOrPut(hash) { mutableListOf() }.add(file)
+    fun addElement(hash: String, element: FileTreeElement): Boolean {
+      val new = hash !in elementsPerHash
+      elementsPerHash.getOrPut(hash) { mutableListOf() }.add(element)
       return new
     }
   }
 
   internal companion object {
-    fun File.sha256Hex(): String {
+    private fun FileTreeElement.sha256Hex(): String {
+      val stream =
+        try {
+          // Open is more performant than getFile, it doesn't extract the zip files.
+          open()
+        } catch (_: UnsupportedOperationException) {
+          file.inputStream()
+        }
+      return stream.use { it.sha256Hex() }
+    }
+
+    private fun InputStream.sha256Hex(): String {
       try {
         val digest = MessageDigest.getInstance("SHA-256")
-        inputStream().use { input ->
-          val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-          while (true) {
-            val count = input.read(buffer)
-            if (count < 0) break
-            digest.update(buffer, 0, count)
-          }
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+          val count = read(buffer)
+          if (count < 0) break
+          digest.update(buffer, 0, count)
         }
         return HexFormat.of().formatHex(digest.digest())
       } catch (e: Exception) {
-        throw RuntimeException("Failed to read data or calculate hash for $this", e)
+        throw RuntimeException("Failed to read data or calculate hash", e)
       }
     }
+
+    fun File.sha256Hex(): String = inputStream().use { it.sha256Hex() }
   }
 }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
@@ -1,6 +1,7 @@
 package com.github.jengelman.gradle.plugins.shadow.transformers
 
 import com.github.jengelman.gradle.plugins.shadow.internal.checkDupStrategy
+import com.github.jengelman.gradle.plugins.shadow.internal.inputStream
 import com.github.jengelman.gradle.plugins.shadow.tasks.FindResourceInClasspath
 import java.io.File
 import java.io.InputStream
@@ -66,7 +67,7 @@ public open class DeduplicatingResourceTransformer(
   @Inject public constructor(objectFactory: ObjectFactory) : this(objectFactory, PatternSet())
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val hash = element.sha256Hex()
+    val hash = element.inputStream.use { it.sha256Hex() }
 
     val flag = patternSpec.isSatisfiedBy(element)
     checkDupStrategy(flag, element)
@@ -124,17 +125,6 @@ public open class DeduplicatingResourceTransformer(
   }
 
   internal companion object {
-    private fun FileTreeElement.sha256Hex(): String {
-      val stream =
-        try {
-          // Open is more performant than getFile, it doesn't extract the zip files.
-          open()
-        } catch (_: UnsupportedOperationException) {
-          file.inputStream()
-        }
-      return stream.use { it.sha256Hex() }
-    }
-
     private fun InputStream.sha256Hex(): String {
       try {
         val digest = MessageDigest.getInstance("SHA-256")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformer.kt
@@ -67,7 +67,7 @@ public open class DeduplicatingResourceTransformer(
   @Inject public constructor(objectFactory: ObjectFactory) : this(objectFactory, PatternSet())
 
   override fun canTransformResource(element: FileTreeElement): Boolean {
-    val hash = element.inputStream.use { it.sha256Hex() }
+    val hash = element.inputStream().use { it.sha256Hex() }
 
     val flag = patternSpec.isSatisfiedBy(element)
     checkDupStrategy(flag, element)
@@ -92,12 +92,7 @@ public open class DeduplicatingResourceTransformer(
           append("  * $path\n")
           infos.elementsPerHash.forEach { (hash, elements) ->
             elements.forEach { element ->
-              val filePath =
-                try {
-                  element.file.path
-                } catch (_: Exception) {
-                  element.path
-                }
+              val filePath = runCatching { element.file.path }.getOrElse { element.path }
               append("    * $filePath (SHA256: $hash)\n")
             }
           }
@@ -113,7 +108,7 @@ public open class DeduplicatingResourceTransformer(
     }
 
   internal data class PathInfos(val failOnDuplicateContent: Boolean) {
-    val elementsPerHash: MutableMap<String, MutableList<FileTreeElement>> = mutableMapOf()
+    val elementsPerHash = mutableMapOf<String, MutableList<FileTreeElement>>()
 
     fun uniqueContentCount() = elementsPerHash.size
 
@@ -125,6 +120,8 @@ public open class DeduplicatingResourceTransformer(
   }
 
   internal companion object {
+    fun File.sha256Hex(): String = inputStream().use { it.sha256Hex() }
+
     private fun InputStream.sha256Hex(): String {
       try {
         val digest = MessageDigest.getInstance("SHA-256")
@@ -139,7 +136,5 @@ public open class DeduplicatingResourceTransformer(
         throw RuntimeException("Failed to read data or calculate hash", e)
       }
     }
-
-    fun File.sha256Hex(): String = inputStream().use { it.sha256Hex() }
   }
 }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/BytecodeRemappingTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/BytecodeRemappingTest.kt
@@ -11,9 +11,11 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator
 import com.github.jengelman.gradle.plugins.shadow.testkit.requireResourceAsPath
 import com.github.jengelman.gradle.plugins.shadow.util.noOpDelegate
 import java.io.File
+import java.io.InputStream
 import java.nio.file.Path
 import kotlin.io.path.copyTo
 import kotlin.io.path.createParentDirectories
+import kotlin.io.path.inputStream
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.relativeTo
 import kotlin.io.path.writeBytes
@@ -277,6 +279,8 @@ class BytecodeRemappingTest {
       override fun getPath(): String = relativeTo(tempDir).invariantSeparatorsPathString
 
       override fun getFile(): File = toFile()
+
+      override fun open(): InputStream = inputStream()
     }
 
   private fun KClass<*>.toFileCopyDetails(): FileCopyDetails {

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/BytecodeRemappingTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/BytecodeRemappingTest.kt
@@ -280,7 +280,7 @@ class BytecodeRemappingTest {
 
       override fun getFile(): File = toFile()
 
-      override fun open(): InputStream = inputStream()
+      override fun open(): InputStream = this@toFileCopyDetails.inputStream()
     }
 
   private fun KClass<*>.toFileCopyDetails(): FileCopyDetails {

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
@@ -53,6 +53,9 @@ abstract class BaseTransformerTest<T : ResourceTransformer> {
           override fun getFile(): File = requireNotNull(file) { "File must be provided." }
 
           override fun open(): InputStream = getFile().inputStream()
+
+          // Mock Gradle's AbstractFileTreeElement.toString, which returns getDisplayName().
+          override fun toString(): String = file?.path ?: path
         }
       return canTransformResource(element)
     }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/BaseTransformerTest.kt
@@ -7,6 +7,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransform
 import com.github.jengelman.gradle.plugins.shadow.util.noOpDelegate
 import com.github.jengelman.gradle.plugins.shadow.util.testObjectFactory
 import java.io.File
+import java.io.InputStream
 import java.lang.reflect.ParameterizedType
 import java.nio.file.Path
 import java.util.Locale
@@ -50,6 +51,8 @@ abstract class BaseTransformerTest<T : ResourceTransformer> {
           override fun getRelativePath(): RelativePath = _relativePath
 
           override fun getFile(): File = requireNotNull(file) { "File must be provided." }
+
+          override fun open(): InputStream = getFile().inputStream()
         }
       return canTransformResource(element)
     }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformerTest.kt
@@ -139,3 +139,6 @@ class DeduplicatingResourceTransformerTest :
         )
     }
 }
+
+private val DeduplicatingResourceTransformer.PathInfos.filesPerHash: Map<String, List<File>>
+  get() = elementsPerHash.mapValues { (_, elements) -> elements.map { it.file } }

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/DeduplicatingResourceTransformerTest.kt
@@ -140,5 +140,5 @@ class DeduplicatingResourceTransformerTest :
     }
 }
 
-private val DeduplicatingResourceTransformer.PathInfos.filesPerHash: Map<String, List<File>>
+private val DeduplicatingResourceTransformer.PathInfos.filesPerHash
   get() = elementsPerHash.mapValues { (_, elements) -> elements.map { it.file } }


### PR DESCRIPTION
`open` gets the streams from zip files:

https://github.com/gradle/gradle/blob/534f27719b66953f95cc907aae7f2c1b12f5482d/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java#L166-L173

`getFile` extracts the entries from zip files:

https://github.com/gradle/gradle/blob/534f27719b66953f95cc907aae7f2c1b12f5482d/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeElement.java#L78-L88

- Closes #1534.
- Closes #2217.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
