### PR TITLE
Deprecate `ApacheLicenseResourceTransformer` and `ManifestAppenderTransformer`

### DIFF
--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -38,6 +38,10 @@
   Use `TransformerContext` constructor instead. The Builder API will be removed in Shadow 10.
 - Deprecate `ManifestResourceTransformer.attributes(Map)`. ([#2200](https://github.com/GradleUp/shadow/pull/2200))  
   Use `manifestEntries` instead. The method will be removed in Shadow 10.
+- Deprecate `ApacheLicenseResourceTransformer`. ([#2221](https://github.com/GradleUp/shadow/pull/2221))  
+  Use `ShadowJar.exclude` or `MergeLicenseResourceTransformer` instead. The class will be removed in Shadow 10.
+- Deprecate `ManifestAppenderTransformer`. ([#2221](https://github.com/GradleUp/shadow/pull/2221))  
+  Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead. The class will be removed in Shadow 10.
 
 ### Fixed
 

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -598,7 +598,6 @@ There are lots of built-in [`ResourceTransformer`][ResourceTransformer]s provide
 [`PatternFilterableResourceTransformer`][PatternFilterableResourceTransformer], which extends
 [`PatternFilterable`][PatternFilterable] to provide `include`/`exclude` pattern filtering capabilities. e.g.
 
-- [`ApacheLicenseResourceTransformer`][ApacheLicenseResourceTransformer]
 - [`ApacheNoticeResourceTransformer`][ApacheNoticeResourceTransformer]
 - [`ProGuardFilesResourceTransformer`][ProGuardFilesResourceTransformer]
 - [`ServiceFileTransformer`][ServiceFileTransformer]
@@ -611,9 +610,9 @@ You can use `include`/`exclude` and more methods to configure the patterns for t
 
     ```kotlin
     tasks.shadowJar {
-      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ApacheLicenseResourceTransformer>() {
-        include("META-INF/LICENSE.*")
-        exclude("META-INF/LICENSE.log")
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>() {
+        include("META-INF/services/com.example.*")
+        exclude("META-INF/services/com.example.Internal")
       }
     }
     ```
@@ -622,12 +621,21 @@ You can use `include`/`exclude` and more methods to configure the patterns for t
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ApacheLicenseResourceTransformer) {
-        include 'META-INF/LICENSE.*'
-        exclude 'META-INF/LICENSE.log'
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer) {
+        include 'META-INF/services/com.example.*'
+        exclude 'META-INF/services/com.example.Internal'
       }
     }
     ```
+
+## Deprecated Resource Transformers
+
+Some earlier [`ResourceTransformer`][ResourceTransformer]s are deprecated in favor of Gradle's native copy features or more modern transformers:
+
+- [`ApacheLicenseResourceTransformer`][ApacheLicenseResourceTransformer]: Deprecated. Use [`ShadowJar.exclude`][ShadowJar.exclude] (e.g. `exclude("META-INF/LICENSE*")`) to exclude license files, or [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer] to merge license files into the output JAR.
+- [`ManifestAppenderTransformer`][ManifestAppenderTransformer]: Deprecated. Use [`ManifestResourceTransformer`][ManifestResourceTransformer] (which supports class relocation within manifest attributes) or Gradle's native `manifest { attributes(...) }` instead.
+- `DontIncludeResourceTransformer`: Deprecated. Use [`ShadowJar.exclude`][ShadowJar.exclude] instead.
+- `IncludeResourceTransformer`: Deprecated. Use [`ShadowJar.from`][ShadowJar.from] instead.
 
 ## Finding Resources in the Classpath
 
@@ -689,3 +697,7 @@ You can then run the task to scan each entry on the classpath and print any matc
 [XmlAppendingTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-xml-appending-transformer/index.html
 [mergeGroovyExtensionModules]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/merge-groovy-extension-modules.html
 [CopySpec]: https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html
+[MergeLicenseResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-merge-license-resource-transformer/index.html
+[ManifestAppenderTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-manifest-appender-transformer/index.html
+[ManifestResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-manifest-resource-transformer/index.html
+[ShadowJar.exclude]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.AbstractCopyTask.html#org.gradle.api.tasks.AbstractCopyTask:exclude(java.lang.Iterable)

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -628,14 +628,78 @@ You can use `include`/`exclude` and more methods to configure the patterns for t
     }
     ```
 
-## Deprecated Resource Transformers
+## Merging License Files
 
-Some earlier [`ResourceTransformer`][ResourceTransformer]s are deprecated in favor of Gradle's native copy features or more modern transformers:
+When multiple dependencies contain license files (such as `META-INF/LICENSE`), you can merge them into a single
+license file in the output JAR using the [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer].
+You can optionally specify your project's license file using `artifactLicense`:
 
-- [`ApacheLicenseResourceTransformer`][ApacheLicenseResourceTransformer]: Deprecated. Use [`ShadowJar.exclude`][ShadowJar.exclude] (e.g. `exclude("META-INF/LICENSE*")`) to exclude license files, or [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer] to merge license files into the output JAR.
-- [`ManifestAppenderTransformer`][ManifestAppenderTransformer]: Deprecated. Use [`ManifestResourceTransformer`][ManifestResourceTransformer] (which supports class relocation within manifest attributes) or Gradle's native `manifest { attributes(...) }` instead.
-- `DontIncludeResourceTransformer`: Deprecated. Use [`ShadowJar.exclude`][ShadowJar.exclude] instead.
-- `IncludeResourceTransformer`: Deprecated. Use [`ShadowJar.from`][ShadowJar.from] instead.
+=== "Kotlin"
+
+    ```kotlin
+    tasks.shadowJar {
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.MergeLicenseResourceTransformer>() {
+        artifactLicense = file("LICENSE")
+      }
+    }
+    ```
+
+=== "Groovy"
+
+    ```groovy
+    tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.MergeLicenseResourceTransformer) {
+        artifactLicense = file('LICENSE')
+      }
+    }
+    ```
+
+If you instead want to discard all license files from the output JAR, you can simply use [`ShadowJar.exclude`][ShadowJar.exclude]:
+
+=== "Kotlin"
+
+    ```kotlin
+    tasks.shadowJar {
+      exclude("META-INF/LICENSE*")
+    }
+    ```
+
+=== "Groovy"
+
+    ```groovy
+    tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      exclude 'META-INF/LICENSE*'
+    }
+    ```
+
+## Transforming and Relocating Manifest Attributes
+
+While standard manifest attributes can be configured using Gradle's native `manifest { ... }` block, the
+[`ManifestResourceTransformer`][ManifestResourceTransformer] allows modifying manifest entries while automatically
+relocating class and package names within configured manifest attributes (such as `Export-Package`, `Import-Package`,
+`Provide-Capability`, `Require-Capability`):
+
+=== "Kotlin"
+
+    ```kotlin
+    tasks.shadowJar {
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer>() {
+        mainClass = "my.Main"
+        manifestEntries.put("Custom-Attribute", "Custom-Value")
+      }
+    }
+    ```
+
+=== "Groovy"
+
+    ```groovy
+    tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer) {
+        mainClass = 'my.Main'
+        manifestEntries.put('Custom-Attribute', 'Custom-Value')
+      }
+    }
+    ```
 
 ## Finding Resources in the Classpath
 
@@ -681,7 +745,6 @@ You can then run the task to scan each entry on the classpath and print any matc
 [Jar]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
 [Log4j2PluginsCacheFileTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-log4j2-plugins-cache-file-transformer/index.html
 [ResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-resource-transformer/index.html
-[ApacheLicenseResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-apache-license-resource-transformer/index.html
 [ApacheNoticeResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-apache-notice-resource-transformer/index.html
 [ProGuardFilesResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-pro-guard-files-resource-transformer/index.html
 [ServiceFileTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-service-file-transformer/index.html
@@ -698,6 +761,5 @@ You can then run the task to scan each entry on the classpath and print any matc
 [mergeGroovyExtensionModules]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/merge-groovy-extension-modules.html
 [CopySpec]: https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html
 [MergeLicenseResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-merge-license-resource-transformer/index.html
-[ManifestAppenderTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-manifest-appender-transformer/index.html
 [ManifestResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-manifest-resource-transformer/index.html
 [ShadowJar.exclude]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.AbstractCopyTask.html#org.gradle.api.tasks.AbstractCopyTask:exclude(java.lang.Iterable)

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -632,7 +632,8 @@ You can use `include`/`exclude` and more methods to configure the patterns for t
 
 When multiple dependencies contain license files (such as `META-INF/LICENSE`), you can merge them into a single
 license file in the output JAR using the [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer].
-You must specify your project's license file using `artifactLicense`: 
+You must specify your project's license file using `artifactLicense`:
+
 === "Kotlin"
 
     ```kotlin

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -632,8 +632,7 @@ You can use `include`/`exclude` and more methods to configure the patterns for t
 
 When multiple dependencies contain license files (such as `META-INF/LICENSE`), you can merge them into a single
 license file in the output JAR using the [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer].
-You can optionally specify your project's license file using `artifactLicense`:
-
+You must specify your project's license file using `artifactLicense`: 
 === "Kotlin"
 
     ```kotlin

--- a/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/SnippetExecutable.kt
+++ b/src/documentTest/kotlin/com/github/jengelman/gradle/plugins/shadow/SnippetExecutable.kt
@@ -87,6 +87,7 @@ sealed interface SnippetExecutable {
         // Dummy JAR file to ensure the project can be built.
         JarOutputStream(projectRoot.resolve("main/$name").outputStream()).use {}
       }
+      projectRoot.resolve("main/LICENSE").writeText("Sample License")
 
       // Script-defined classes (e.g., inline custom ResourceTransformer) are not supported by
       // CC/IP because transient script classloaders cannot be serialized.

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -8,7 +8,6 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
-import com.github.jengelman.gradle.plugins.shadow.testkit.crlfEolString
 import com.github.jengelman.gradle.plugins.shadow.testkit.getBytes
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import com.github.jengelman.gradle.plugins.shadow.testkit.getStream
@@ -382,40 +381,6 @@ class TransformersTest : BaseTransformerTest() {
     assertThat(outputShadowedJar).useAll {
       containsOnly("META-INF/", "META-INF/kotlin-stdlib.shadow.kotlin_module", *manifestEntries)
       getBytes("META-INF/kotlin-stdlib.shadow.kotlin_module").isNotEqualTo(moduleBytes)
-    }
-  }
-
-  @Test
-  fun manifestResourceTransformerAppendEntries() {
-    val one = buildJarOne {
-      insert("foo/bar.txt", "bar")
-    }
-    projectScript.appendText(
-      transform<ManifestResourceTransformer>(
-        dependenciesBlock = implementationFiles(one),
-        transformerBlock =
-          """
-          |manifestEntries.put('Name', 'org/foo/bar/')
-          |manifestEntries.put('Sealed', 'true')
-          """
-            .trimMargin(),
-      )
-    )
-
-    runWithSuccess(shadowJarPath)
-
-    assertThat(outputShadowedJar).useAll {
-      getContent("META-INF/MANIFEST.MF")
-        .isEqualTo(
-          """
-          |Manifest-Version: 1.0
-          |Name: org/foo/bar/
-          |Sealed: true
-          |
-          |"""
-            .trimMargin()
-            .crlfEolString
-        )
     }
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
+import com.github.jengelman.gradle.plugins.shadow.testkit.crlfEolString
 import com.github.jengelman.gradle.plugins.shadow.testkit.getBytes
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import com.github.jengelman.gradle.plugins.shadow.testkit.getStream
@@ -381,6 +382,40 @@ class TransformersTest : BaseTransformerTest() {
     assertThat(outputShadowedJar).useAll {
       containsOnly("META-INF/", "META-INF/kotlin-stdlib.shadow.kotlin_module", *manifestEntries)
       getBytes("META-INF/kotlin-stdlib.shadow.kotlin_module").isNotEqualTo(moduleBytes)
+    }
+  }
+
+  @Test
+  fun manifestResourceTransformerAppendEntries() {
+    val one = buildJarOne {
+      insert("foo/bar.txt", "bar")
+    }
+    projectScript.appendText(
+      transform<ManifestResourceTransformer>(
+        dependenciesBlock = implementationFiles(one),
+        transformerBlock =
+          """
+          |manifestEntries.put('Name', 'org/foo/bar/')
+          |manifestEntries.put('Sealed', 'true')
+          """
+            .trimMargin(),
+      )
+    )
+
+    runWithSuccess(shadowJarPath)
+
+    assertThat(outputShadowedJar).useAll {
+      getContent("META-INF/MANIFEST.MF")
+        .isEqualTo(
+          """
+          |Manifest-Version: 1.0
+          |Name: org/foo/bar/
+          |Sealed: true
+          |
+          |"""
+            .trimMargin()
+            .crlfEolString
+        )
     }
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -8,7 +8,6 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
-import com.github.jengelman.gradle.plugins.shadow.testkit.crlfEolString
 import com.github.jengelman.gradle.plugins.shadow.testkit.getBytes
 import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import com.github.jengelman.gradle.plugins.shadow.testkit.getStream
@@ -202,27 +201,6 @@ class TransformersTest : BaseTransformerTest() {
   }
 
   @Test
-  fun apacheLicenseResourceTransformer() {
-    val one = buildJarOne {
-      insert("META-INF/LICENSE", "License 1")
-      insert("foo/bar.txt", "bar")
-    }
-    val two = buildJarTwo {
-      insert("META-INF/LICENSE.txt", "License 2")
-      insert("foo/baz.txt", "baz")
-    }
-    projectScript.appendText(
-      transform<ApacheLicenseResourceTransformer>(dependenciesBlock = implementationFiles(one, two))
-    )
-
-    runWithSuccess(shadowJarPath)
-
-    assertThat(outputShadowedJar).useAll {
-      containsOnly("foo/", "foo/bar.txt", "foo/baz.txt", *manifestEntries)
-    }
-  }
-
-  @Test
   fun apacheNoticeResourceTransformer() {
     val one = buildJarOne {
       insert("META-INF/NOTICE", "Notice from A")
@@ -361,41 +339,6 @@ class TransformersTest : BaseTransformerTest() {
     assertThat(outputShadowedJar).useAll {
       containsOnly("META-INF/", "META-INF/kotlin-stdlib.shadow.kotlin_module", *manifestEntries)
       getBytes("META-INF/kotlin-stdlib.shadow.kotlin_module").isNotEqualTo(moduleBytes)
-    }
-  }
-
-  @Test
-  fun manifestAppenderTransformer() {
-    val one = buildJarOne {
-      insert("foo/bar.txt", "bar")
-    }
-    projectScript.appendText(
-      transform<ManifestAppenderTransformer>(
-        dependenciesBlock = implementationFiles(one),
-        transformerBlock =
-          """
-          |it.append('Name', 'org/foo/bar/')
-          |it.append('Sealed', 'true')
-          """
-            .trimMargin(),
-      )
-    )
-
-    runWithSuccess(shadowJarPath)
-
-    assertThat(outputShadowedJar).useAll {
-      getContent("META-INF/MANIFEST.MF")
-        .isEqualTo(
-          """
-          |Manifest-Version: 1.0
-          |
-          |Name: org/foo/bar/
-          |Sealed: true
-          |
-          |"""
-            .trimMargin()
-            .crlfEolString
-        )
     }
   }
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/TransformersTest.kt
@@ -201,6 +201,48 @@ class TransformersTest : BaseTransformerTest() {
   }
 
   @Test
+  fun mergeLicenseResourceTransformer() {
+    path("LICENSE").writeText("Sample Project License")
+    val one = buildJarOne {
+      insert("META-INF/LICENSE", "License from One")
+    }
+    val two = buildJarTwo {
+      insert("META-INF/LICENSE.txt", "License from Two")
+    }
+    projectScript.appendText(
+      transform<MergeLicenseResourceTransformer>(
+        dependenciesBlock = implementationFiles(one, two),
+        transformerBlock = "artifactLicense = file('LICENSE')",
+      )
+    )
+
+    runWithSuccess(shadowJarPath)
+
+    assertThat(outputShadowedJar).useAll {
+      containsOnly("META-INF/", "META-INF/LICENSE", *manifestEntries)
+      getContent("META-INF/LICENSE")
+        .isEqualTo(
+          """
+          |SPDX-License-Identifier: Apache-2.0
+          |Sample Project License
+          |
+          |------------------------------------------------------------------------------------------------------------------------
+          |
+          |This artifact includes dependencies with the following licenses:
+          |----------------------------------------------------------------
+          |
+          |License from One
+          |
+          |------------------------------------------------------------------------------------------------------------------------
+          |
+          |License from Two
+          """
+            .trimMargin()
+        )
+    }
+  }
+
+  @Test
   fun apacheNoticeResourceTransformer() {
     val one = buildJarOne {
       insert("META-INF/NOTICE", "Notice from A")

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformer.kt
@@ -12,6 +12,11 @@ import org.gradle.api.tasks.util.PatternSet
  *
  * @author John Engelman
  */
+@Deprecated(
+  message =
+    "Use `ShadowJar.exclude` or `MergeLicenseResourceTransformer` instead. This will be removed in Shadow 10.",
+  replaceWith = ReplaceWith("exclude"),
+)
 @CacheableTransformer
 public open class ApacheLicenseResourceTransformer
 @JvmOverloads

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -25,12 +25,7 @@ import org.gradle.api.tasks.Input
  */
 @Deprecated(
   message =
-    "Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead. This will be removed in Shadow 10.",
-  replaceWith =
-    ReplaceWith(
-      "ManifestResourceTransformer",
-      "com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer",
-    ),
+    "Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead. This will be removed in Shadow 10."
 )
 @CacheableTransformer
 public open class ManifestAppenderTransformer

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -26,7 +26,11 @@ import org.gradle.api.tasks.Input
 @Deprecated(
   message =
     "Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead. This will be removed in Shadow 10.",
-  replaceWith = ReplaceWith("transform(ManifestResourceTransformer::class.java)"),
+  replaceWith =
+    ReplaceWith(
+      "ManifestResourceTransformer",
+      "com.github.jengelman.gradle.plugins.shadow.transformers.ManifestResourceTransformer",
+    ),
 )
 @CacheableTransformer
 public open class ManifestAppenderTransformer

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformer.kt
@@ -23,6 +23,11 @@ import org.gradle.api.tasks.Input
  *
  * @author Chris Rankin
  */
+@Deprecated(
+  message =
+    "Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead. This will be removed in Shadow 10.",
+  replaceWith = ReplaceWith("transform(ManifestResourceTransformer::class.java)"),
+)
 @CacheableTransformer
 public open class ManifestAppenderTransformer
 @Inject
@@ -72,6 +77,7 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
     attributes.add(name to value)
   }
 
+  @Suppress("DEPRECATION")
   private companion object {
     private val logger = Logging.getLogger(ManifestAppenderTransformer::class.java)
     private val EOL = "\r\n".toByteArray()

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ApacheLicenseResourceTransformerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
  * Modified from
  * [org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformerTest.java](https://github.com/apache/maven-shade-plugin/blob/master/src/test/java/org/apache/maven/plugins/shade/resource/ApacheLicenseResourceTransformerTest.java).
  */
+@Suppress("DEPRECATION")
 class ApacheLicenseResourceTransformerTest :
   BaseTransformerTest<ApacheLicenseResourceTransformer>() {
 

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/ManifestAppenderTransformerTest.kt
@@ -9,6 +9,7 @@ import com.github.jengelman.gradle.plugins.shadow.testkit.getContent
 import java.util.jar.JarFile.MANIFEST_NAME
 import org.junit.jupiter.api.Test
 
+@Suppress("DEPRECATION")
 class ManifestAppenderTransformerTest : BaseTransformerTest<ManifestAppenderTransformer>() {
   @Test
   fun canTransformResource() =


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
