### PR TITLE
Allow passing classpath files in R8 minimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Support removing manifest attributes using `NULL`.
   - Support manifest header relocation via configurable `attributesToRelocate` property.
 - Allow disabling default ProGuard rules in R8 minimization with `R8Spec.useDefaultRules`. ([#2252](https://github.com/GradleUp/shadow/pull/2252))
+- Allow passing classpath files to R8 minimization with `R8Spec.classpath`. ([#2255](https://github.com/GradleUp/shadow/pull/2255))
 
 ### Changed
 

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -226,6 +226,7 @@ public abstract interface class com/github/jengelman/gradle/plugins/shadow/tasks
 	public abstract fun enableObfuscation ()V
 	public abstract fun enableOptimization ()V
 	public abstract fun getArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfigurationFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public fun getKeepRuleFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getKeepRules ()Lorg/gradle/api/provider/ListProperty;

--- a/docs/configuration/minimizing/README.md
+++ b/docs/configuration/minimizing/README.md
@@ -213,6 +213,46 @@ These reporting options belong in the build's R8 configuration, not in rules pub
 Android's [library optimization guidance][library-optimization-guidance] lists them among the global options that
 library authors should not publish as consumer keep rules.
 
+When your classes reference types that are available on the compile classpath but not bundled into the shadowed JAR
+(such as `compileOnly` dependencies or `gradleApi()`), supply them to R8 via `classpath` so R8 can analyze the complete
+class hierarchy without bundling those dependencies into the output archive:
+
+=== ":material-language-kotlin: build.gradle.kts"
+
+    ```kotlin
+    repositories {
+      google()
+    }
+
+    val compileClasspath = configurations.compileClasspath
+
+    tasks.shadowJar {
+      minimize {
+        r8 {
+          classpath.from(compileClasspath)
+        }
+      }
+    }
+    ```
+
+=== ":simple-apachegroovy: build.gradle"
+
+    ```groovy
+    repositories {
+      google()
+    }
+
+    def compileClasspath = configurations.compileClasspath
+
+    tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      minimize {
+        r8 {
+          classpath.from(compileClasspath)
+        }
+      }
+    }
+    ```
+
 Shadow resolves R8 from the `shadowR8` configuration. The default dependency is `com.android.tools:r8`, which is
 published by Google Maven rather than Maven Central. Add `google()` to your repositories or override the dependency:
 

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/R8MinimizationTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/R8MinimizationTest.kt
@@ -1,9 +1,12 @@
 package com.github.jengelman.gradle.plugins.shadow
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.hasMessage
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.Companion.SHADOW_JAR_TASK_NAME
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
 import com.github.jengelman.gradle.plugins.shadow.testkit.classLoader
@@ -452,6 +455,65 @@ class R8MinimizationTest : BasePluginTest() {
     val result = runWithSuccess(appShadowJarPath)
 
     assertThat(result.output).contains("R8 launcher JDK ${JavaVersion.current().majorVersion}")
+  }
+
+  @Test
+  fun supportClasspathInR8() {
+    writeR8AppAndLibModules(
+      appShadowBlock =
+        """
+        |minimize {
+        |  r8 {
+        |    classpath.from(project.configurations.compileClasspath)
+        |  }
+        |}
+        """
+          .trimMargin(),
+      appProjectBlock =
+        """
+        |dependencies {
+        |  compileOnly 'junit:junit:3.8.2'
+        |}
+        """
+          .trimMargin(),
+    )
+
+    path("app/src/main/java/app/App.java")
+      .writeText(
+        """
+        |package app;
+        |import junit.framework.Test;
+        |import junit.framework.TestResult;
+        |import lib.Used;
+        |public class App implements Test {
+        |  @Override
+        |  public int countTestCases() {
+        |    return 1;
+        |  }
+        |  @Override
+        |  public void run(TestResult result) {
+        |    Used.name();
+        |  }
+        |}
+        """
+          .trimMargin()
+      )
+
+    runWithSuccess(appShadowJarPath)
+
+    assertThat(outputAppShadowedJar).useAll {
+      containsExactly(
+        "app/App.class",
+        "lib/Used.class",
+        manifestEntry,
+      )
+      classLoader {
+        loadClass("lib.Used")
+        assertFailure { loadClass("app.App") }
+          .isInstanceOf<NoClassDefFoundError>()
+          .hasMessage("junit/framework/Test") // Compile only on junit dependency.
+      }
+    }
   }
 
   private fun writeR8AppAndLibModules(

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/DefaultR8Spec.kt
@@ -30,6 +30,8 @@ constructor(
 
   override val proguardRuleFiles: ConfigurableFileCollection = objectFactory.fileCollection()
 
+  override val classpath: ConfigurableFileCollection = objectFactory.fileCollection()
+
   override val configurationFile: RegularFileProperty =
     objectFactory
       .fileProperty()

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/R8Minimizer.kt
@@ -81,6 +81,12 @@ internal fun minimizeWithR8(
     add(configurationFile.absolutePath)
     add("--lib")
     add(javaHome)
+    r8Spec.classpath
+      .filter { it.exists() }
+      .forEach { file ->
+        add("--classpath")
+        add(file.absolutePath)
+      }
     addAll(r8Args)
     add(inputJar.absolutePath)
   }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/R8Spec.kt
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
@@ -60,6 +61,14 @@ public interface R8Spec {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   public val proguardRuleFiles: ConfigurableFileCollection
+
+  /**
+   * Classpath files used by R8 for class hierarchy and dependency analysis, but not included in the
+   * output JAR (e.g. `compileOnly` dependencies, `gradleApi()`).
+   *
+   * Defaults to empty.
+   */
+  @get:CompileClasspath public val classpath: ConfigurableFileCollection
 
   /**
    * The collective ProGuard configuration output by R8.

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/MinimizeSpecsTest.kt
@@ -42,6 +42,7 @@ class MinimizeSpecsTest {
       assertThat(optimizationEnabled.get()).isFalse()
       assertThat(proguardRules.get()).isEmpty()
       assertThat(proguardRuleFiles.files).isEmpty()
+      assertThat(classpath.files).isEmpty()
       assertThat(configurationFile.get().asFile)
         .isEqualTo(
           project.layout.buildDirectory.file("shadowJar/r8/configuration.txt").get().asFile


### PR DESCRIPTION
Inspired by https://github.com/GradleUp/gr8/blob/f6fae257512101e7789dad9a78501c945409f0c0/gr8-plugin-common/src/main/kotlin/com/gradleup/gr8/Gr8Configurator.kt#L69-L76.

---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
