### PR TITLE
Deprecate `mergeGroovyExtensionModules` and `append` in `ShadowJar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
   Use `ShadowJar.exclude` or `MergeLicenseResourceTransformer` instead.
 - Deprecate `ManifestAppenderTransformer`. ([#2221](https://github.com/GradleUp/shadow/pull/2221))  
   Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead.
-- Deprecate `mergeGroovyExtensionModules` and `append` in `ShadowJar`.  
+- Deprecate `mergeGroovyExtensionModules` and `append` in `ShadowJar`. ([#2261](https://github.com/GradleUp/shadow/pull/2261))  
   Use `transform<GroovyExtensionModuleTransformer>()` and `transform<AppendingTransformer>()` instead.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   Use `ShadowJar.exclude` or `MergeLicenseResourceTransformer` instead.
 - Deprecate `ManifestAppenderTransformer`. ([#2221](https://github.com/GradleUp/shadow/pull/2221))  
   Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead.
+- Deprecate `mergeServiceFiles`, `mergeGroovyExtensionModules`, and `append` in `ShadowJar`.  
+  Use `transform<ServiceFileTransformer>()`, `transform<GroovyExtensionModuleTransformer>()`, and `transform<AppendingTransformer>()` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@
   Use `ShadowJar.exclude` or `MergeLicenseResourceTransformer` instead.
 - Deprecate `ManifestAppenderTransformer`. ([#2221](https://github.com/GradleUp/shadow/pull/2221))  
   Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead.
-- Deprecate `mergeServiceFiles`, `mergeGroovyExtensionModules`, and `append` in `ShadowJar`.  
-  Use `transform<ServiceFileTransformer>()`, `transform<GroovyExtensionModuleTransformer>()`, and `transform<AppendingTransformer>()` instead.
+- Deprecate `mergeGroovyExtensionModules` and `append` in `ShadowJar`.  
+  Use `transform<GroovyExtensionModuleTransformer>()` and `transform<AppendingTransformer>()` instead.
 
 ### Fixed
 

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -77,7 +77,7 @@ If you mix the usages of `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` and
     ```kotlin
     tasks.shadowJar {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // The default strategy.
-      mergeServiceFiles()
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
     }
     ```
 
@@ -86,7 +86,7 @@ If you mix the usages of `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` and
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // The default strategy.
-      mergeServiceFiles()
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
     }
     ```
 
@@ -143,7 +143,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
       // Step 2.
-      mergeServiceFiles()
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
       // Step 3. Using `filesNotMatching`:
       filesNotMatching("META-INF/services/**") {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
@@ -158,7 +158,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
       // Step 2.
-      mergeServiceFiles()
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
       // Step 3. Using `filesMatching`:
       filesMatching("META-INF/services/**") {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
@@ -184,7 +184,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
       // Step 2.
-      mergeServiceFiles()
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
       // Step 3. Using `filesNotMatching`:
       filesNotMatching('META-INF/services/**') {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
@@ -199,7 +199,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
       // Step 2.
-      mergeServiceFiles()
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
       // Step 3. Using `filesMatching`:
       filesMatching('META-INF/services/**') {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
@@ -333,18 +333,12 @@ runtime, this file is read and used to configure library or application behavior
 Multiple dependencies may use the same service descriptor file name. In this case, it is generally desired to merge the
 content of each instance of the file into a single output file. The [`ServiceFileTransformer`][ServiceFileTransformer]
 class is used to perform this merging. By default, it will merge each copy of a file under `META-INF/services` into a
-single file in the output JAR. You can use either the short syntax method
-[`mergeServiceFiles()`][ShadowJar.mergeServiceFiles] or the full syntax method [`transform`][ShadowJar.transform] to add
-the [`ServiceFileTransformer`][ServiceFileTransformer]:
+single file in the output JAR:
 
 === ":material-language-kotlin: build.gradle.kts"
 
     ```kotlin
     tasks.shadowJar {
-      // Short syntax.
-      mergeServiceFiles()
-
-      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
     }
     ```
@@ -353,10 +347,6 @@ the [`ServiceFileTransformer`][ServiceFileTransformer]:
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      // Short syntax.
-      mergeServiceFiles()
-
-      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
     }
     ```
@@ -368,7 +358,7 @@ the [`ServiceFileTransformer`][ServiceFileTransformer]:
 > `META-INF/services/org.codehaus.groovy.runtime.ExtensionModule`) are ignored by the
 > [`ServiceFileTransformer`][ServiceFileTransformer].
 > This is due to these files having a different syntax than standard service descriptor files.
-> Use the [`mergeGroovyExtensionModules()`][mergeGroovyExtensionModules] method to merge these files if your
+> Use the [`GroovyExtensionModuleTransformer`][GroovyExtensionModuleTransformer] to merge these files if your
 > dependencies contain them.
 
 ### Configuring the Location of Service Descriptor Files
@@ -380,12 +370,6 @@ This directory can be overridden to merge descriptor files in a different locati
 
     ```kotlin
     tasks.shadowJar {
-      // Short syntax.
-      mergeServiceFiles {
-        path = "META-INF/custom"
-      }
-
-      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer> {
         path = "META-INF/custom"
       }
@@ -396,12 +380,6 @@ This directory can be overridden to merge descriptor files in a different locati
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      // Short syntax.      
-      mergeServiceFiles {
-        path = 'META-INF/custom'
-      }
-
-      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer) {
         path = 'META-INF/custom'
       }
@@ -417,12 +395,6 @@ from merging.
 
     ```kotlin
     tasks.shadowJar {
-      // Short syntax.
-      mergeServiceFiles {
-        exclude("META-INF/services/com.acme.*")
-      }
-
-      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer> {
         exclude("META-INF/services/com.acme.*")
       }
@@ -433,12 +405,6 @@ from merging.
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      // Short syntax.
-      mergeServiceFiles {
-        exclude 'META-INF/services/com.acme.*'
-      }
-
-      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer) {
         exclude 'META-INF/services/com.acme.*'
       }
@@ -449,17 +415,12 @@ from merging.
 
 Shadow provides a specific transformer for dealing with Groovy extension module files. This is due to their special
 syntax and how they need to be merged together. The
-[`GroovyExtensionModuleTransformer`][GroovyExtensionModuleTransformer] will handle these files. The
-[`ShadowJar`][ShadowJar] task also provides a short syntax method to add this transformer.
+[`GroovyExtensionModuleTransformer`][GroovyExtensionModuleTransformer] will handle these files.
 
 === ":material-language-kotlin: build.gradle.kts"
 
     ```kotlin
     tasks.shadowJar {
-      // Short syntax.
-      mergeGroovyExtensionModules()
-
-      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer>()
     }
     ```
@@ -468,10 +429,6 @@ syntax and how they need to be merged together. The
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      // Short syntax.
-      mergeGroovyExtensionModules()
-
-      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer)
     }
     ```
@@ -503,14 +460,15 @@ Log4j 2.x Core components. It's a Gradle equivalent of
 ## Appending Text Files
 
 Generic text files can be appended together using the [`AppendingTransformer`][AppendingTransformer]. Each file is
-appended using separators (defaults to `\n`) to separate content. The [`ShadowJar`][ShadowJar] task provides a short
-syntax method of [`append(String)`][ShadowJar.append] to configure this transformer.
+appended using separators (defaults to `\n`) to separate content.
 
 === ":material-language-kotlin: build.gradle.kts"
 
     ```kotlin
     tasks.shadowJar {
-      append("test.properties")
+      transform<com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer> {
+        resource = "test.properties"
+      }
     }
     ```
 
@@ -518,7 +476,9 @@ syntax method of [`append(String)`][ShadowJar.append] to configure this transfor
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      append 'test.properties'
+      transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
+        resource = 'test.properties'
+      }
     }
     ```
 
@@ -526,9 +486,6 @@ syntax method of [`append(String)`][ShadowJar.append] to configure this transfor
 
     ```kotlin
     tasks.shadowJar {
-      // short syntax
-      append("resources/application.yml", "\n---\n")
-      // full syntax
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer> {
         resource = "resources/custom-config/application.yml"
         separator = "\n---\n"
@@ -540,9 +497,6 @@ syntax method of [`append(String)`][ShadowJar.append] to configure this transfor
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-      // short syntax
-      append('resources/application.yml', '\n---\n')
-      // full syntax
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
         resource = 'resources/custom-config/application.yml'
         separator = '\n---\n'
@@ -966,15 +920,12 @@ You can then run the task to scan each entry on the classpath and print any matc
 [ServiceFileTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-service-file-transformer/index.html
 [PatternFilterable]: https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.tasks.util/-pattern-filterable/index.html
 [PatternFilterableResourceTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-pattern-filterable-resource-transformer/index.html
-[ShadowJar.append]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/append.html
 [ShadowJar.exclude]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.AbstractCopyTask.html#org.gradle.api.tasks.AbstractCopyTask:exclude(java.lang.Iterable)
 [ShadowJar.failOnDuplicateEntries]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/fail-on-duplicate-entries.html
 [ShadowJar.from]: https://docs.gradle.org/current/dsl/org.gradle.jvm.tasks.Jar.html#org.gradle.jvm.tasks.Jar:from(java.lang.Object,%20org.gradle.api.Action)
-[ShadowJar.mergeServiceFiles]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/merge-service-files.html
 [ShadowJar.transform]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/transform.html
 [ShadowJar]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/index.html
 [XmlAppendingTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-xml-appending-transformer/index.html
-[mergeGroovyExtensionModules]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/merge-groovy-extension-modules.html
 [CopySpec]: https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html
 [shadowjar-execution-flow]: ../README.md#shadowjar-execution-flow
 [Diffuse]: https://github.com/JakeWharton/diffuse

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -77,7 +77,7 @@ If you mix the usages of `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` and
     ```kotlin
     tasks.shadowJar {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // The default strategy.
-      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
+      mergeServiceFiles()
     }
     ```
 
@@ -86,7 +86,7 @@ If you mix the usages of `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` and
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // The default strategy.
-      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
+      mergeServiceFiles()
     }
     ```
 
@@ -143,7 +143,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
       // Step 2.
-      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
+      mergeServiceFiles()
       // Step 3. Using `filesNotMatching`:
       filesNotMatching("META-INF/services/**") {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
@@ -158,7 +158,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
       // Step 2.
-      transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
+      mergeServiceFiles()
       // Step 3. Using `filesMatching`:
       filesMatching("META-INF/services/**") {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
@@ -184,7 +184,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
       // Step 2.
-      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
+      mergeServiceFiles()
       // Step 3. Using `filesNotMatching`:
       filesNotMatching('META-INF/services/**') {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
@@ -199,7 +199,7 @@ Here are some examples:
       // Step 1.
       duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Or FAIL.
       // Step 2.
-      transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
+      mergeServiceFiles()
       // Step 3. Using `filesMatching`:
       filesMatching('META-INF/services/**') {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE // Or WARN.
@@ -333,12 +333,18 @@ runtime, this file is read and used to configure library or application behavior
 Multiple dependencies may use the same service descriptor file name. In this case, it is generally desired to merge the
 content of each instance of the file into a single output file. The [`ServiceFileTransformer`][ServiceFileTransformer]
 class is used to perform this merging. By default, it will merge each copy of a file under `META-INF/services` into a
-single file in the output JAR:
+single file in the output JAR. You can use either the short syntax method
+[`mergeServiceFiles()`][ShadowJar.mergeServiceFiles] or the full syntax method [`transform`][ShadowJar.transform] to add
+the [`ServiceFileTransformer`][ServiceFileTransformer]:
 
 === ":material-language-kotlin: build.gradle.kts"
 
     ```kotlin
     tasks.shadowJar {
+      // Short syntax.
+      mergeServiceFiles()
+
+      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer>()
     }
     ```
@@ -347,6 +353,10 @@ single file in the output JAR:
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      // Short syntax.
+      mergeServiceFiles()
+
+      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
     }
     ```
@@ -370,6 +380,12 @@ This directory can be overridden to merge descriptor files in a different locati
 
     ```kotlin
     tasks.shadowJar {
+      // Short syntax.
+      mergeServiceFiles {
+        path = "META-INF/custom"
+      }
+
+      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer> {
         path = "META-INF/custom"
       }
@@ -380,6 +396,12 @@ This directory can be overridden to merge descriptor files in a different locati
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      // Short syntax.      
+      mergeServiceFiles {
+        path = 'META-INF/custom'
+      }
+
+      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer) {
         path = 'META-INF/custom'
       }
@@ -395,6 +417,12 @@ from merging.
 
     ```kotlin
     tasks.shadowJar {
+      // Short syntax.
+      mergeServiceFiles {
+        exclude("META-INF/services/com.acme.*")
+      }
+
+      // Full syntax.
       transform<com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer> {
         exclude("META-INF/services/com.acme.*")
       }
@@ -405,6 +433,12 @@ from merging.
 
     ```groovy
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+      // Short syntax.
+      mergeServiceFiles {
+        exclude 'META-INF/services/com.acme.*'
+      }
+
+      // Full syntax.
       transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer) {
         exclude 'META-INF/services/com.acme.*'
       }
@@ -923,6 +957,7 @@ You can then run the task to scan each entry on the classpath and print any matc
 [ShadowJar.exclude]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.AbstractCopyTask.html#org.gradle.api.tasks.AbstractCopyTask:exclude(java.lang.Iterable)
 [ShadowJar.failOnDuplicateEntries]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/fail-on-duplicate-entries.html
 [ShadowJar.from]: https://docs.gradle.org/current/dsl/org.gradle.jvm.tasks.Jar.html#org.gradle.jvm.tasks.Jar:from(java.lang.Object,%20org.gradle.api.Action)
+[ShadowJar.mergeServiceFiles]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/merge-service-files.html
 [ShadowJar.transform]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/transform.html
 [ShadowJar]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.tasks/-shadow-jar/index.html
 [XmlAppendingTransformer]: ../../api/shadow/com.github.jengelman.gradle.plugins.shadow.transformers/-xml-appending-transformer/index.html

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/CachingTest.kt
@@ -8,6 +8,7 @@ import com.github.jengelman.gradle.plugins.shadow.internal.mainClassAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.testkit.JarPath
 import com.github.jengelman.gradle.plugins.shadow.testkit.containsOnly
 import com.github.jengelman.gradle.plugins.shadow.testkit.getMainAttr
+import com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import kotlin.io.path.appendText
@@ -491,9 +492,7 @@ class CachingTest : BasePluginTest() {
 
     projectScript.appendText(
       """
-      |$shadowJarTask {
-      |  mergeGroovyExtensionModules()
-      |}
+      |${transform<GroovyExtensionModuleTransformer>()}
       |
       """
         .trimMargin()

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/AppendingTransformerTest.kt
@@ -12,15 +12,10 @@ class AppendingTransformerTest : BaseTransformerTest() {
     val one = buildJarOne { insert(ENTRY_TEST_PROPERTIES, CONTENT_ONE) }
     val two = buildJarTwo { insert(ENTRY_TEST_PROPERTIES, CONTENT_TWO) }
     projectScript.appendText(
-      """
-      |dependencies {
-      |  ${implementationFiles(one, two)}
-      |}
-      |$shadowJarTask {
-      |  append('$ENTRY_TEST_PROPERTIES')
-      |}
-      """
-        .trimMargin()
+      transform<AppendingTransformer>(
+        dependenciesBlock = implementationFiles(one, two),
+        transformerBlock = "resource = '$ENTRY_TEST_PROPERTIES'",
+      )
     )
 
     runWithSuccess(shadowJarPath)

--- a/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformerTest.kt
+++ b/src/functionalTest/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/GroovyExtensionModuleTransformerTest.kt
@@ -19,15 +19,9 @@ class GroovyExtensionModuleTransformerTest : BaseTransformerTest() {
   @Test
   fun groovyExtensionModuleTransformer() {
     projectScript.appendText(
-      """
-      |dependencies {
-      |  ${implementationFiles(buildJarFoo(), buildJarBar())}
-      |}
-      |$shadowJarTask {
-      |  mergeGroovyExtensionModules()
-      |}
-      """
-        .trimMargin()
+      transform<GroovyExtensionModuleTransformer>(
+        dependenciesBlock = implementationFiles(buildJarFoo(), buildJarBar())
+      )
     )
 
     runWithSuccess(shadowJarPath)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -358,17 +358,8 @@ public abstract class ShadowJar : Jar() {
    *
    * @see [getDuplicatesStrategy]
    */
-  @Deprecated(
-    message =
-      "Use `transform<ServiceFileTransformer>()` instead. This will be removed in Shadow 10.",
-    replaceWith =
-      ReplaceWith(
-        "transform<ServiceFileTransformer> { it.path = rootPath }",
-        "com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer",
-      ),
-  )
   public open fun mergeServiceFiles(rootPath: String) {
-    transform(ServiceFileTransformer::class.java) { it.path = rootPath }
+    mergeServiceFiles { it.path = rootPath }
   }
 
   /**
@@ -381,15 +372,6 @@ public abstract class ShadowJar : Jar() {
    *
    * @see [getDuplicatesStrategy]
    */
-  @Deprecated(
-    message =
-      "Use `transform<ServiceFileTransformer>()` instead. This will be removed in Shadow 10.",
-    replaceWith =
-      ReplaceWith(
-        "transform<ServiceFileTransformer>(action)",
-        "com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer",
-      ),
-  )
   @JvmOverloads
   public open fun mergeServiceFiles(action: Action<ServiceFileTransformer> = Action {}) {
     transform(ServiceFileTransformer::class.java, action)

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -358,8 +358,17 @@ public abstract class ShadowJar : Jar() {
    *
    * @see [getDuplicatesStrategy]
    */
+  @Deprecated(
+    message =
+      "Use `transform<ServiceFileTransformer>()` instead. This will be removed in Shadow 10.",
+    replaceWith =
+      ReplaceWith(
+        "transform<ServiceFileTransformer> { it.path = rootPath }",
+        "com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer",
+      ),
+  )
   public open fun mergeServiceFiles(rootPath: String) {
-    mergeServiceFiles { it.path = rootPath }
+    transform(ServiceFileTransformer::class.java) { it.path = rootPath }
   }
 
   /**
@@ -372,6 +381,15 @@ public abstract class ShadowJar : Jar() {
    *
    * @see [getDuplicatesStrategy]
    */
+  @Deprecated(
+    message =
+      "Use `transform<ServiceFileTransformer>()` instead. This will be removed in Shadow 10.",
+    replaceWith =
+      ReplaceWith(
+        "transform<ServiceFileTransformer>(action)",
+        "com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer",
+      ),
+  )
   @JvmOverloads
   public open fun mergeServiceFiles(action: Action<ServiceFileTransformer> = Action {}) {
     transform(ServiceFileTransformer::class.java, action)
@@ -387,6 +405,15 @@ public abstract class ShadowJar : Jar() {
    *
    * @see [getDuplicatesStrategy]
    */
+  @Deprecated(
+    message =
+      "Use `transform<GroovyExtensionModuleTransformer>()` instead. This will be removed in Shadow 10.",
+    replaceWith =
+      ReplaceWith(
+        "transform<GroovyExtensionModuleTransformer>()",
+        "com.github.jengelman.gradle.plugins.shadow.transformers.GroovyExtensionModuleTransformer",
+      ),
+  )
   public open fun mergeGroovyExtensionModules() {
     transform(GroovyExtensionModuleTransformer::class.java, action = {})
   }
@@ -406,6 +433,14 @@ public abstract class ShadowJar : Jar() {
    * @param separator The separator to use between the original content and the appended content,
    *   defaults to [AppendingTransformer.DEFAULT_SEPARATOR] (`\n`).
    */
+  @Deprecated(
+    message = "Use `transform<AppendingTransformer>()` instead. This will be removed in Shadow 10.",
+    replaceWith =
+      ReplaceWith(
+        "transform<AppendingTransformer> { it.resource.set(resourcePath); it.separator.set(separator) }",
+        "com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer",
+      ),
+  )
   @JvmOverloads
   public open fun append(
     resourcePath: String,

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -419,7 +419,7 @@ public abstract class ShadowJar : Jar() {
     message = "Use `transform<AppendingTransformer>()` instead. This will be removed in Shadow 10.",
     replaceWith =
       ReplaceWith(
-        "transform<AppendingTransformer> { it.resource.set(resourcePath); it.separator.set(separator) }",
+        "transform<AppendingTransformer> { resource.set(resourcePath); separator.set(separator) }",
         "com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer",
       ),
   )


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
