### PR TITLE
Deprecate `relocate(Class, Action)` and `relocate<R>()` in `ShadowJar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   Use `ManifestResourceTransformer` or `ShadowJar.manifest` instead.
 - Deprecate `mergeGroovyExtensionModules` and `append` in `ShadowJar`. ([#2261](https://github.com/GradleUp/shadow/pull/2261))  
   Use `transform<GroovyExtensionModuleTransformer>()` and `transform<AppendingTransformer>()` instead.
+- Deprecate `ShadowJar.relocate(Class, Action)` and `ShadowJar.relocate<R>()`. ([#2262](https://github.com/GradleUp/shadow/pull/2262))  
+  Construct a `Relocator` instance and use `ShadowJar.relocate(Relocator, Action)` instead.
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -445,7 +445,10 @@ public abstract class ShadowJar : Jar() {
     addRelocator(relocator, action)
   }
 
-  /** Relocate classes and resources using a [Relocator]. */
+  @Deprecated(
+    message =
+      "Construct a Relocator instance and use relocate(Relocator, Action) instead. This will be removed in Shadow 10."
+  )
   @JvmOverloads
   public open fun <R : Relocator> relocate(clazz: Class<R>, action: Action<R> = Action {}) {
     val relocator = clazz.getDeclaredConstructor().newInstance()
@@ -458,10 +461,14 @@ public abstract class ShadowJar : Jar() {
     addRelocator(relocator, action)
   }
 
-  /** Relocate classes and resources using a [Relocator]. */
+  @Suppress("DeprecatedCallableAddReplaceWith")
+  @Deprecated(
+    message =
+      "Construct a Relocator instance and use relocate(Relocator, Action) instead. This will be removed in Shadow 10."
+  )
   @JvmSynthetic
   public inline fun <reified R : Relocator> relocate(action: Action<R> = Action {}) {
-    relocate(R::class.java, action)
+    @Suppress("DEPRECATION") relocate(R::class.java, action)
   }
 
   /**


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
