### PR TITLE
Make `PropertiesFileTransformer` inherit `PatternFilterableResourceTransformer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Support manifest header relocation via configurable `attributesToRelocate` property.
 - Allow disabling default ProGuard rules in R8 minimization with `R8Spec.useDefaultRules`. ([#2252](https://github.com/GradleUp/shadow/pull/2252))
 - Allow passing classpath files to R8 minimization with `R8Spec.classpath`. ([#2255](https://github.com/GradleUp/shadow/pull/2255))
+- Make `PropertiesFileTransformer` inherit `PatternFilterableResourceTransformer`. ([#2263](https://github.com/GradleUp/shadow/pull/2263))
 
 ### Changed
 
@@ -49,6 +50,8 @@
   Use `transform<GroovyExtensionModuleTransformer>()` and `transform<AppendingTransformer>()` instead.
 - Deprecate `ShadowJar.relocate(Class, Action)` and `ShadowJar.relocate<R>()`. ([#2262](https://github.com/GradleUp/shadow/pull/2262))  
   Construct a `Relocator` instance and use `ShadowJar.relocate(Relocator, Action)` instead.
+- Deprecate `PropertiesFileTransformer.paths`. ([#2263](https://github.com/GradleUp/shadow/pull/2263))  
+  Use `include(..)` instead.
 
 ### Fixed
 

--- a/api/shadow.api
+++ b/api/shadow.api
@@ -527,8 +527,9 @@ public class com/github/jengelman/gradle/plugins/shadow/transformers/ProGuardFil
 	public fun transform (Lcom/github/jengelman/gradle/plugins/shadow/transformers/TransformerContext;)V
 }
 
-public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/ResourceTransformer {
+public class com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer : com/github/jengelman/gradle/plugins/shadow/transformers/PatternFilterableResourceTransformer {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/tasks/util/PatternSet;)V
 	public fun canTransformResource (Lorg/gradle/api/file/FileTreeElement;)Z
 	public fun getCharsetName ()Lorg/gradle/api/provider/Property;
 	public fun getKeyTransformer ()Lkotlin/jvm/functions/Function1;

--- a/docs/configuration/merging/README.md
+++ b/docs/configuration/merging/README.md
@@ -602,6 +602,7 @@ There are lots of built-in [`ResourceTransformer`][ResourceTransformer]s provide
 - [`MergeLicenseResourceTransformer`][MergeLicenseResourceTransformer]
 - [`PreserveFirstFoundResourceTransformer`][PreserveFirstFoundResourceTransformer]
 - [`ProGuardFilesResourceTransformer`][ProGuardFilesResourceTransformer]
+- [`PropertiesFileTransformer`][PropertiesFileTransformer]
 - [`ServiceFileTransformer`][ServiceFileTransformer]
 
 You can use `include`/`exclude` and more methods to configure the patterns for those
@@ -642,7 +643,7 @@ found for duplicate property keys. You can customize the merge behavior with sev
 - `MergeStrategy.Append`: Combines duplicate property values using `mergeSeparator` (default `,`).
 - `MergeStrategy.Fail`: Fails the build if duplicate keys have conflicting values.
 
-You can also specify specific file paths or regular expressions to match using `paths`, configure per-path merge
+You can also specify specific file patterns to match using `include`/`exclude`, configure per-path merge
 strategies using `mappings`, rewrite property keys using `keyTransformer`, or change file encoding using
 `charsetName` (defaults to `ISO-8859-1`).
 
@@ -654,7 +655,7 @@ strategies using `mappings`, rewrite property keys using `keyTransformer`, or ch
 
     tasks.shadowJar {
       transform<PropertiesFileTransformer> {
-        paths.add("META-INF/test.properties")
+        include("META-INF/test.properties")
         mergeStrategy = MergeStrategy.Append
         mergeSeparator = ";"
       }
@@ -669,7 +670,7 @@ strategies using `mappings`, rewrite property keys using `keyTransformer`, or ch
 
     tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
       transform(PropertiesFileTransformer) {
-        paths.add('META-INF/test.properties')
+        include 'META-INF/test.properties'
         mergeStrategy = MergeStrategy.Append
         mergeSeparator = ';'
       }

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformer.kt
@@ -19,6 +19,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.util.PatternSet
 
 /**
  * Resources transformer that merges Properties files.
@@ -65,13 +66,11 @@ import org.gradle.api.tasks.Internal
  * With `mergeStrategy = MergeStrategy.Fail` the transformation will fail if there are conflicting
  * values.
  *
- * There are three additional properties that can be set: [paths], [mappings], and [keyTransformer].
- * The first contains a list of strings or regexes that will be used to determine if a path should
- * be transformed or not. The merge strategy and merge separator are taken from the global settings.
+ * Use the [include] or [exclude] functions inherited from [PatternSet] to configure which property
+ * files are transformed. The merge strategy and merge separator are taken from the global settings.
  *
- * The [mappings] property allows you to define merge strategy and separator per path. If either
- * [paths] or [mappings] is defined then no other path entries will be merged. [mappings] has
- * precedence over [paths] if both are defined.
+ * The [mappings] property allows you to define merge strategy and separator per path. If [mappings]
+ * is defined then no other path entries will be merged.
  *
  * If you need to transform keys in properties files, e.g. because they contain class names about to
  * be relocated, you can set the [keyTransformer] property to a closure that receives the original
@@ -82,9 +81,7 @@ import org.gradle.api.tasks.Internal
  * import org.codehaus.griffon.gradle.shadow.transformers.*
  * tasks.named('shadowJar', ShadowJar) {
  *   transform(PropertiesFileTransformer) {
- *     paths = [
- *       'META-INF/editors/java.beans.PropertyEditor'
- *     ]
+ *     include 'META-INF/editors/java.beans.PropertyEditor'
  *     keyTransformer = { key ->
  *       key.replaceAll('^(orig\.package\..*)$', 'new.prefix.$1')
  *     }
@@ -99,9 +96,10 @@ import org.gradle.api.tasks.Internal
  * @author Marc Philipp
  */
 @CacheableTransformer
-public open class PropertiesFileTransformer
-@Inject
-constructor(final override val objectFactory: ObjectFactory) : ResourceTransformer {
+public open class PropertiesFileTransformer(
+  final override val objectFactory: ObjectFactory,
+  patternSet: PatternSet,
+) : PatternFilterableResourceTransformer(patternSet) {
   private inline val charset
     get() = Charset.forName(charsetName.get())
 
@@ -109,7 +107,12 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
 
   @get:Internal internal val propertiesEntries = mutableMapOf<String, ReproducibleProperties>()
 
-  @get:Input public open val paths: SetProperty<String> = objectFactory.setProperty()
+  @get:Deprecated(
+    message = "Use `include(..)` instead. This will be removed in Shadow 10.",
+    replaceWith = ReplaceWith("include()"),
+  )
+  @get:Input
+  public open val paths: SetProperty<String> = objectFactory.setProperty()
 
   @get:Input
   public open val mappings: MapProperty<String, Map<String, String>> = objectFactory.mapProperty()
@@ -128,18 +131,34 @@ constructor(final override val objectFactory: ObjectFactory) : ResourceTransform
   // https://github.com/GradleUp/shadow/pull/1208.
   public open var keyTransformer: (String) -> String = IDENTITY
 
+  @Inject
+  public constructor(
+    objectFactory: ObjectFactory
+  ) : this(
+    objectFactory,
+    PatternSet(),
+  )
+
   override fun canTransformResource(element: FileTreeElement): Boolean {
     val mappings = mappings.get()
-    val paths = paths.get()
+    val paths = @Suppress("DEPRECATION") paths.get()
     val path = element.path
 
-    return when {
-      path in mappings -> true
-      mappings.keys.any { it.toRegex().containsMatchIn(path) } -> true
-      path in paths -> true
-      paths.any { it.toRegex().containsMatchIn(path) } -> true
-      else -> mappings.isEmpty() && paths.isEmpty() && path.endsWith(PROPERTIES_SUFFIX)
-    }.also { checkDupStrategy(it, element) }
+    val flag =
+      when {
+        path in mappings -> true
+        mappings.keys.any { it.toRegex().containsMatchIn(path) } -> true
+        path in paths -> true
+        paths.any { it.toRegex().containsMatchIn(path) } -> true
+        includes.isNotEmpty() -> patternSpec.isSatisfiedBy(element)
+        else ->
+          mappings.isEmpty() &&
+            paths.isEmpty() &&
+            path.endsWith(PROPERTIES_SUFFIX) &&
+            patternSpec.isSatisfiedBy(element)
+      }
+
+    return flag.also { checkDupStrategy(it, element) }
   }
 
   override fun transform(context: TransformerContext) {

--- a/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
+++ b/src/test/kotlin/com/github/jengelman/gradle/plugins/shadow/transformers/PropertiesFileTransformerTest.kt
@@ -82,6 +82,7 @@ class PropertiesFileTransformerTest : BaseTransformerTest<PropertiesFileTransfor
         )
     }
 
+  @Suppress("DEPRECATION")
   @ParameterizedTest
   @MethodSource("transformConfigWithPathsProvider")
   fun exerciseAllTransformConfigurationsWithPaths(
@@ -101,6 +102,29 @@ class PropertiesFileTransformerTest : BaseTransformerTest<PropertiesFileTransfor
       }
 
       assertThat(propertiesEntries[path].orEmpty()).isEqualTo(expectedOutput)
+    }
+
+  @Test
+  fun patternFilteringWithIncludeAndExclude() =
+    with(transformer) {
+      include("a.properties", "sub/dir/*.properties")
+      exclude("sub/dir/excluded.properties")
+
+      assertThat(canTransformResource("a.properties")).isTrue()
+      assertThat(canTransformResource("sub/dir/b.properties")).isTrue()
+      assertThat(canTransformResource("sub/dir/excluded.properties")).isFalse()
+      assertThat(canTransformResource("other.properties")).isFalse()
+    }
+
+  @Test
+  fun patternFilteringWithOnlyExclude() =
+    with(transformer) {
+      exclude("sub/dir/excluded.properties")
+
+      assertThat(canTransformResource("a.properties")).isTrue()
+      assertThat(canTransformResource("sub/dir/b.properties")).isTrue()
+      assertThat(canTransformResource("sub/dir/excluded.properties")).isFalse()
+      assertThat(canTransformResource("other.txt")).isFalse()
     }
 
   @ParameterizedTest
@@ -171,7 +195,7 @@ class PropertiesFileTransformerTest : BaseTransformerTest<PropertiesFileTransfor
   fun mergedPropertiesWithoutComments() =
     with(transformer) {
       val path = "META-INF/test.properties"
-      paths.set(listOf(path))
+      include(path)
       mergeStrategy.set(MergeStrategy.Append)
 
       val text1 = "# A comment from jar one.\nfoo=one"


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
