### PR TITLE
Deprecate `configureJavaGradlePlugin` in `ShadowJavaPlugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
   Use `transform<GroovyExtensionModuleTransformer>()` and `transform<AppendingTransformer>()` instead.
 - Deprecate `ShadowJar.relocate(Class, Action)` and `ShadowJar.relocate<R>()`. ([#2262](https://github.com/GradleUp/shadow/pull/2262))  
   Construct a `Relocator` instance and use `ShadowJar.relocate(Relocator, Action)` instead.
+- Deprecate `ShadowJavaPlugin.configureJavaGradlePlugin()`. ([#2267](https://github.com/GradleUp/shadow/pull/2267))
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.kt
@@ -32,7 +32,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
       configureShadowJar()
       configureConfigurations()
       configureComponents()
-      configureJavaGradlePlugin()
+      @Suppress("DEPRECATION") configureJavaGradlePlugin()
     }
 
   protected open fun Project.configureShadowJar() {
@@ -129,6 +129,7 @@ constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Pl
     }
   }
 
+  @Deprecated("This method will be removed in Shadow 10.")
   protected open fun Project.configureJavaGradlePlugin() {}
 
   public companion object {


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/GradleUp/shadow/blob/main/CHANGELOG.md)'s "Unreleased" section has been updated, if applicable.
