### PR TITLE
Remove `_minimizeJar` from `sourceSetsClassesDirs` convention

### DIFF
--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/internal/GradleCompat.kt
@@ -35,6 +35,9 @@ internal inline val Project.runtimeConfiguration: Configuration
 internal inline val Project.sourceSets: SourceSetContainer
   get() = extensions.getByType(SourceSetContainer::class.java)
 
+internal inline val Project.sourceSetsOrNull: SourceSetContainer?
+  get() = extensions.findByType(SourceSetContainer::class.java)
+
 internal inline val Project.distributions: DistributionContainer
   get() = extensions.getByType(DistributionContainer::class.java)
 

--- a/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
+++ b/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/tasks/ShadowJar.kt
@@ -20,7 +20,7 @@ import com.github.jengelman.gradle.plugins.shadow.internal.minimizeWithR8
 import com.github.jengelman.gradle.plugins.shadow.internal.multiReleaseAttributeKey
 import com.github.jengelman.gradle.plugins.shadow.internal.property
 import com.github.jengelman.gradle.plugins.shadow.internal.setProperty
-import com.github.jengelman.gradle.plugins.shadow.internal.sourceSets
+import com.github.jengelman.gradle.plugins.shadow.internal.sourceSetsOrNull
 import com.github.jengelman.gradle.plugins.shadow.internal.useZip
 import com.github.jengelman.gradle.plugins.shadow.relocation.CacheableRelocator
 import com.github.jengelman.gradle.plugins.shadow.relocation.Relocator
@@ -139,14 +139,10 @@ public abstract class ShadowJar : Jar() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   public open val sourceSetsClassesDirs: ConfigurableFileCollection = objectFactory.fileCollection {
-    _minimizeJar.map {
-      if (it) {
-        project.sourceSets.map { sourceSet ->
-          sourceSet.output.classesDirs.filter(File::isDirectory)
-        }
-      } else {
-        emptySet()
-      }
+    project.provider {
+      project.sourceSetsOrNull?.map { sourceSet ->
+        sourceSet.output.classesDirs.filter(File::isDirectory)
+      } ?: emptySet<File>()
     }
   }
 


### PR DESCRIPTION
`_minimizeJar` is unrelated for `sourceSetsClassesDirs`, and `sourceSetsClassesDirs` is not annotated with `@get:Classpath`. It should be safe to remove the extra flag.

Refs #2276.